### PR TITLE
Manifest and other things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Code issues we discover are now displayed as a checklist item
+- The Preflight manifest now shows findings, permissions, and vulnerabilities
+- When Recon mode is enabled, we now show a message if we've found historical code issues on a source file you're looking at
+- When the Preflight manifest is enabled, you can now click on a checklist item to jump to that section of the manifest
+
+### Fixed
+
+- Improved reliability of showing Preflight checklist and experimental Recon issue markers on the page
+- Fixed some performance issues with the sidebar
+- Fixed an issue where we'd display permissions in the manifest even if they weren't found in the project
+
 ## [1.8.3] - 2018-09-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-fetch-component": "^6.1.0",
+    "react-markdown": "^3.6.0",
     "react-scripts-ts": "2.17.0",
     "react-timeago": "^4.1.9",
     "react-transition-group": "^2.4.0"

--- a/src/api/findings.ts
+++ b/src/api/findings.ts
@@ -16,6 +16,7 @@ export function postFindingsUrl(domain: string, org: string, repo: string) {
 
 export interface FindingsResponse {
   gitUrl: string;
+  commitHash: string;
   findings: FindingEntry[] | undefined;
 }
 

--- a/src/api/findings.ts
+++ b/src/api/findings.ts
@@ -1,4 +1,12 @@
-export function findingsUrl(domain: string, org: string, repo: string) {
+import { ExtractedRepoSlug, extractSlugFromCurrentUrl } from "../utils";
+
+export function findingsUrl() {
+  const repoSlug = extractSlugFromCurrentUrl();
+
+  return findingsUrlFromSlug(repoSlug);
+}
+
+export function findingsUrlFromSlug({ domain, org, repo }: ExtractedRepoSlug) {
   return `https://api.secarta.io/v1/finding/${domain}/${org}/${repo}`;
 }
 
@@ -8,7 +16,7 @@ export function postFindingsUrl(domain: string, org: string, repo: string) {
 
 export interface FindingsResponse {
   gitUrl: string;
-  findings: FindingEntry[];
+  findings: FindingEntry[] | undefined;
 }
 
 export interface FindingEntry {

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -16,6 +16,8 @@ export interface PackageEntry {
 
 export interface ScriptEntry {
   script: string;
+
+  // Disabling TSlint because the API returns a property called `type`
   // tslint:disable-next-line:no-reserved-keywords
   type: string;
 }

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -16,7 +16,8 @@ export interface PackageEntry {
 
 export interface ScriptEntry {
   script: string;
-  kind: string;
+  // tslint:disable-next-line:no-reserved-keywords
+  type: string;
 }
 
 export interface PackageResponse {

--- a/src/api/vulns.ts
+++ b/src/api/vulns.ts
@@ -8,26 +8,31 @@ export function vulnsUrl() {
 
 export interface VulnsResponse {
   gitUrl: string;
+  vuln: VulnerabilityEntriesContainer[];
+}
+
+export interface VulnerabilityEntriesContainer {
+  package_name: string;
   vuln: VulnerabilityEntry[];
 }
 
 export interface VulnerabilityEntry {
-    allowed_scopes: string[];
-    author: string;
-    created_at: Date;
-    cves: string[];
-    cvss_score: number;
-    cvss_vector: string;
-    cwe: string;
-    id: number;
-    module_name: string;
-    overview: string;
-    patched_versions: string;
-    publish_date: string;
-    recommendation: string;
-    references: string;
-    slug: string;
-    title: string;
-    updated_at: Date;
-    vulnerable_versions: string;
+  allowed_scopes: string[];
+  author: string;
+  created_at: Date;
+  cves: string[];
+  cvss_score: number;
+  cvss_vector: string;
+  cwe: string;
+  id: number;
+  module_name: string;
+  overview: string;
+  patched_versions: string;
+  publish_date: string;
+  recommendation: string;
+  references: string;
+  slug: string;
+  title: string;
+  updated_at: Date;
+  vulnerable_versions: string;
 }

--- a/src/content/FindingsGroupedList.css
+++ b/src/content/FindingsGroupedList.css
@@ -14,3 +14,13 @@
   justify-content: space-between;
   align-items: center;
 }
+
+.findings-group-entries .bp3-button {
+  padding: 0;
+  border-radius: 0;
+  min-height: inherit;
+}
+
+.findings-group-entries .bp3-button-text {
+  flex: 1 1 auto;
+}

--- a/src/content/FindingsGroupedList.tsx
+++ b/src/content/FindingsGroupedList.tsx
@@ -8,25 +8,29 @@ import "./FindingsGroupedList.css";
 
 interface FindingsGroupedListProps {
   findings: FindingEntry[];
+  commitHash: string;
   repoSlug?: ExtractedRepoSlug;
   className?: string;
 }
 
 interface FindingsGroupProps {
   fileName: string;
+  commitHash: string;
   findings: FindingEntry[];
   repoSlug?: ExtractedRepoSlug;
 }
 
 class FindingsGroup extends React.PureComponent<FindingsGroupProps> {
   public render() {
-    const { repoSlug, fileName } = this.props;
+    const { repoSlug, commitHash, fileName } = this.props;
 
     return (
       <section className="findings-group">
         <header>
           {repoSlug != null ? (
-            <a href={buildFindingFileLink(repoSlug, null, fileName, null)}>
+            <a
+              href={buildFindingFileLink(repoSlug, commitHash, fileName, null)}
+            >
               {this.props.fileName}
             </a>
           ) : (
@@ -72,7 +76,7 @@ export default class FindingsGroupedList extends React.PureComponent<
   FindingsGroupedListProps
 > {
   public render() {
-    const { findings, repoSlug } = this.props;
+    const { findings, repoSlug, commitHash } = this.props;
     const sortedAndGrouped = this.sortAndGroupByFile(findings);
 
     return (
@@ -84,6 +88,7 @@ export default class FindingsGroupedList extends React.PureComponent<
           .map(fileName => (
             <FindingsGroup
               key={fileName}
+              commitHash={commitHash}
               fileName={fileName}
               repoSlug={repoSlug}
               findings={sortedAndGrouped[fileName]}

--- a/src/content/FindingsGroupedList.tsx
+++ b/src/content/FindingsGroupedList.tsx
@@ -40,10 +40,8 @@ class FindingsGroup extends React.PureComponent<FindingsGroupProps> {
               key={`${finding.fileName} ${finding.startLine} ${
                 finding.analyzerName
               } ${finding.checkId} ${i}`}
-              className={classnames(
-                { [Classes.DISABLED]: repoSlug == null },
-                Classes.FILL
-              )}
+              className={classnames({ [Classes.DISABLED]: repoSlug == null })}
+              fill={true}
               href={
                 repoSlug != null
                   ? buildFindingFileLink(

--- a/src/content/FindingsGroupedList.tsx
+++ b/src/content/FindingsGroupedList.tsx
@@ -1,4 +1,6 @@
+import { AnchorButton, Classes } from "@blueprintjs/core";
 import { FindingEntry } from "@r2c/extension/api/findings";
+import { buildFindingFileLink, ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import { groupBy, mapValues, sortBy } from "lodash";
 import * as React from "react";
@@ -6,32 +8,61 @@ import "./FindingsGroupedList.css";
 
 interface FindingsGroupedListProps {
   findings: FindingEntry[];
+  repoSlug?: ExtractedRepoSlug;
   className?: string;
 }
 
 interface FindingsGroupProps {
   fileName: string;
   findings: FindingEntry[];
+  repoSlug?: ExtractedRepoSlug;
 }
 
 class FindingsGroup extends React.PureComponent<FindingsGroupProps> {
   public render() {
+    const { repoSlug, fileName } = this.props;
+
     return (
       <section className="findings-group">
-        <header>{this.props.fileName}</header>
+        <header>
+          {repoSlug != null ? (
+            <a href={buildFindingFileLink(repoSlug, null, fileName, null)}>
+              {this.props.fileName}
+            </a>
+          ) : (
+            this.props.fileName
+          )}
+        </header>
         <div className="findings-group-entries">
           {this.props.findings.map((finding, i) => (
-            <div
-              className="finding-entry"
+            <AnchorButton
+              minimal={true}
               key={`${finding.fileName} ${finding.startLine} ${
                 finding.analyzerName
               } ${finding.checkId} ${i}`}
+              className={classnames(
+                { [Classes.DISABLED]: repoSlug == null },
+                Classes.FILL
+              )}
+              href={
+                repoSlug != null
+                  ? buildFindingFileLink(
+                      repoSlug,
+                      finding.commitHash,
+                      fileName,
+                      finding.startLine,
+                      finding.endLine
+                    )
+                  : undefined
+              }
             >
-              <span className="finding-entry-startline">
-                {finding.startLine}
-              </span>
-              <span className="finding-entry-checkid">{finding.checkId}</span>
-            </div>
+              <div className="finding-entry">
+                <span className="finding-entry-startline">
+                  {finding.startLine}
+                </span>
+                <span className="finding-entry-checkid">{finding.checkId}</span>
+              </div>
+            </AnchorButton>
           ))}
         </div>
       </section>
@@ -43,7 +74,7 @@ export default class FindingsGroupedList extends React.PureComponent<
   FindingsGroupedListProps
 > {
   public render() {
-    const { findings } = this.props;
+    const { findings, repoSlug } = this.props;
     const sortedAndGrouped = this.sortAndGroupByFile(findings);
 
     return (
@@ -56,6 +87,7 @@ export default class FindingsGroupedList extends React.PureComponent<
             <FindingsGroup
               key={fileName}
               fileName={fileName}
+              repoSlug={repoSlug}
               findings={sortedAndGrouped[fileName]}
             />
           ))}

--- a/src/content/FindingsTwist.tsx
+++ b/src/content/FindingsTwist.tsx
@@ -21,41 +21,46 @@ const FindingsList: React.SFC<FindingsTwistProps> = ({
     return (
       <>
         {loading && <section className="findings loading">Loading...</section>}
-        {error && (
-          <section className="findings error">Couldn't load findings</section>
-        )}
-        {data && (
-          <>
-            <section className="findings">
-              {data.findings.map((finding, i) => (
-                <article className="finding" key={i}>
-                  <header className="finding-header">
-                    <h2 className="finding-checkid">{finding.checkId}</h2>
-                    <span className="finding-full-path">
-                      <a
-                        href={buildFindingFileLink(
-                          repoSlug,
-                          finding.commitHash,
-                          finding.fileName,
-                          finding.startLine
-                        )}
-                      >
-                        <span className="finding-path-filename">
-                          {finding.fileName}
-                        </span>
-                        {finding.startLine != null && (
-                          <span className="finding-line-number">
-                            :{finding.startLine}
+        {error ||
+          (data &&
+            data.findings == null && (
+              <section className="findings error">
+                Couldn't load findings
+              </section>
+            ))}
+        {data &&
+          data.findings != null && (
+            <>
+              <section className="findings">
+                {data.findings.map((finding, i) => (
+                  <article className="finding" key={i}>
+                    <header className="finding-header">
+                      <h2 className="finding-checkid">{finding.checkId}</h2>
+                      <span className="finding-full-path">
+                        <a
+                          href={buildFindingFileLink(
+                            repoSlug,
+                            finding.commitHash,
+                            finding.fileName,
+                            finding.startLine
+                          )}
+                        >
+                          <span className="finding-path-filename">
+                            {finding.fileName}
                           </span>
-                        )}
-                      </a>
-                    </span>
-                  </header>
-                </article>
-              ))}
-            </section>
-          </>
-        )}
+                          {finding.startLine != null && (
+                            <span className="finding-line-number">
+                              :{finding.startLine}
+                            </span>
+                          )}
+                        </a>
+                      </span>
+                    </header>
+                  </article>
+                ))}
+              </section>
+            </>
+          )}
       </>
     );
   } else {

--- a/src/content/PreflightTwist.css
+++ b/src/content/PreflightTwist.css
@@ -12,8 +12,26 @@
   font-weight: 600;
 }
 
+.preflight-section-header .bp3-button-text {
+  flex: 1 1 auto;
+}
+
+.preflight-section-header-text {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .preflight-section .preflight-section-description {
   margin-top: 1ex;
   font-size: 12px;
   color: rgba(16, 22, 26, 0.6);
+}
+
+.preflight-section-header.bp3-fill {
+  display: flex;
+  justify-content: space-between;
+  margin-left: -10px;
+  margin-right: -10px;
 }

--- a/src/content/PreflightTwist.css
+++ b/src/content/PreflightTwist.css
@@ -35,3 +35,11 @@
   margin-left: -10px;
   margin-right: -10px;
 }
+
+.preflight-section.preflight-vulns .preflight-vulnerability-entry {
+  margin-bottom: 10px;
+}
+
+.preflight-section.preflight-vulns .preflight-vulnerability-entry:last-child {
+  margin-bottom: 0;
+}

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -10,14 +10,120 @@ import {
   permissionsUrl
 } from "@r2c/extension/api/permissions";
 import { RepoResponse, repoUrl } from "@r2c/extension/api/repo";
-import { VulnsResponse, vulnsUrl } from "@r2c/extension/api/vulns";
+import {
+  VulnerabilityEntry,
+  VulnsResponse,
+  vulnsUrl
+} from "@r2c/extension/api/vulns";
 import FindingsGroupedList from "@r2c/extension/content/FindingsGroupedList";
 import { buildFindingFileLink, ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import * as React from "react";
 import Fetch from "react-fetch-component";
+import * as Markdown from "react-markdown";
+import TimeAgo from "react-timeago";
 import { PreflightChecklistItemType } from "./headsup/PreflightChecklist";
 import "./PreflightTwist.css";
+import "./PreflightVulnerabilityEntry.css";
+
+interface PreflightVulnerabilityEntryProps {
+  vuln: VulnerabilityEntry;
+}
+
+interface PreflightVulnerabilityEntryState {
+  showMore: boolean;
+}
+
+class PreflightVulnerabilityEntry extends React.PureComponent<
+  PreflightVulnerabilityEntryProps,
+  PreflightVulnerabilityEntryState
+> {
+  public state: PreflightVulnerabilityEntryState = {
+    showMore: false
+  };
+
+  public render() {
+    const { vuln } = this.props;
+    const { showMore } = this.state;
+
+    return (
+      <article className="preflight-vulnerability-entry">
+        <header>
+          <div className="vuln-cves">
+            {vuln.cves.length > 0 ? (
+              vuln.cves.map(cve => (
+                <div className="vuln-cve" key={cve}>
+                  {cve}
+                </div>
+              ))
+            ) : (
+              <span className="no-vuln-cve">No CVE assigned</span>
+            )}
+          </div>
+          <h2 className="vuln-title">{vuln.title}</h2>
+          <div className="vuln-versions">
+            <span className="vuln-affected">
+              Vulnerable{" "}
+              <span className="vuln-version">{vuln.vulnerable_versions}</span>
+            </span>
+            <span className="vuln-patched">
+              Patched{" "}
+              <span className="vuln-version">{vuln.patched_versions}</span>
+            </span>
+          </div>
+          <div className="vuln-metadata">
+            Found{" "}
+            <span className="vuln-published">
+              <TimeAgo date={new Date(vuln.publish_date)} />
+            </span>{" "}
+            by <span className="vuln-author">{vuln.author}</span>
+          </div>
+        </header>
+        {showMore && (
+          <div
+            className={classnames("vuln-body", {
+              visible: showMore,
+              hidden: !showMore
+            })}
+          >
+            <section className="vuln-overview">
+              <header>Overview</header>
+              <Markdown source={vuln.overview} />
+            </section>
+            <section className="vuln-recommendations">
+              <header>Recommendations</header>
+              <Markdown source={vuln.recommendation} />
+            </section>
+            <section className="vuln-references">
+              <header>References</header>
+              <Markdown source={vuln.references} />
+            </section>
+            <section className="vuln-errata">
+              <header>Errata</header>
+              <dl>
+                <dt>CVSS Vector</dt>
+                <dd>{vuln.cvss_vector}</dd>
+                <dt>CVSS Score</dt>
+                <dd>{vuln.cvss_score}</dd>
+              </dl>
+            </section>
+          </div>
+        )}
+        <Button
+          className="vuln-show-more-button"
+          minimal={true}
+          fill={true}
+          onClick={this.handleToggleShowMore}
+        >
+          Show {showMore ? "less" : "more"}
+        </Button>
+      </article>
+    );
+  }
+
+  private handleToggleShowMore: React.MouseEventHandler<HTMLElement> = e =>
+    this.setState({ showMore: !this.state.showMore });
+}
 
 interface PreflightSectionProps {
   check: PreflightChecklistItemType;
@@ -141,166 +247,174 @@ export default class PreflightTwist extends React.PureComponent<
         <header className="twist-header">
           <h1 className="twist-title">Manifest</h1>
         </header>
-        <div className="twist-body">
-          <Fetch<PermissionsResponse> url={permissionsUrl()}>
-            {({ data, loading }) => (
-              <PreflightSection
-                check="permissions"
-                title="Permissions"
-                description="The project's capabilities when it runs. Unexpected capabilities can indicate a security breach or malice."
-                startOpen={
-                  data != null &&
-                  data.permissions != null &&
-                  Object.keys(data.permissions)
-                    .map(key => data.permissions[key].found)
-                    .some(f => f === true)
-                }
-                count={
-                  data != null
-                    ? Object.keys(data.permissions)
-                        .map(key => data.permissions[key].found)
-                        .filter(f => f === true).length
-                    : undefined
-                }
-                loading={loading}
-                domRef={this.twistRefs.permissions}
-              >
-                {data != null &&
-                  data.permissions != null && (
-                    <>
-                      {Object.keys(data.permissions).map(
-                        key =>
-                          data.permissions[key].found && (
-                            <div className="permission-entry" key={key}>
-                              <span className="permission-entry-name">
-                                {data.permissions[key].displayName}
-                              </span>
-                              {data.permissions[key].locations.map(
-                                location =>
-                                  location.file_name != null &&
-                                  location.start_line != null && (
-                                    <a
-                                      href={buildFindingFileLink(
-                                        repoSlug,
-                                        data.commitHash,
-                                        location.file_name,
-                                        location.start_line
-                                      )}
-                                    >
-                                      {location.file_name}:{location.start_line}
-                                    </a>
-                                  )
-                              )}
-                            </div>
-                          )
-                      )}
-                    </>
-                  )}
-              </PreflightSection>
-            )}
-          </Fetch>
-          <Fetch<VulnsResponse> url={vulnsUrl()}>
-            {({ data, loading }) => (
-              <PreflightSection
-                check="vulns"
-                title="Vulnerabilities"
-                description="Current or historical vulnerabilities discovered in this project."
-                startOpen={data != null && data.vuln.length > 0}
-                count={data != null ? data.vuln.length : undefined}
-                loading={loading}
-                domRef={this.twistRefs.vulns}
-              >
-                {data != null &&
-                  data.vuln.map((vuln, i) => (
-                    <div className="vulns-raw" key={i}>
-                      <pre>{JSON.stringify(vuln, undefined, 2)}</pre>
-                    </div>
-                  ))}
-              </PreflightSection>
-            )}
-          </Fetch>
-          <Fetch<FindingsResponse> url={findingsUrlFromSlug(repoSlug)}>
-            {({ data, loading, error }) => (
-              <PreflightSection
-                check="findings"
-                title="Findings"
-                description="Weaknesses or bad practices that we automatically discovered in this project."
-                startOpen={
-                  data != null &&
-                  data.findings != null &&
-                  data.findings.length > 0
-                }
-                count={
-                  data != null && data.findings != null
-                    ? data.findings.length
-                    : undefined
-                }
-                loading={loading}
-                domRef={this.twistRefs.findings}
-              >
-                {data != null &&
-                  data.findings != null && (
-                    <FindingsGroupedList
-                      findings={data.findings}
-                      repoSlug={repoSlug}
-                    />
-                  )}
-              </PreflightSection>
-            )}
-          </Fetch>
-          <Fetch<PackageResponse> url={packageUrl()}>
-            {({ data, loading }) => (
-              <>
+        <div className="twist-scroll-container">
+          <div className="twist-body">
+            <Fetch<PermissionsResponse> url={permissionsUrl()}>
+              {({ data, loading }) => (
                 <PreflightSection
-                  check="scripts"
-                  title="Install hooks"
-                  description="Hooks can run before or after installing this package, and their presence can indicate a security issue."
-                  startOpen={data != null && data.npmScripts.length > 0}
-                  count={data != null ? data.npmScripts.length : undefined}
+                  check="permissions"
+                  title="Permissions"
+                  description="The project's capabilities when it runs. Unexpected capabilities can indicate a security breach or malice."
+                  startOpen={
+                    data != null &&
+                    data.permissions != null &&
+                    Object.keys(data.permissions)
+                      .map(key => data.permissions[key].found)
+                      .some(f => f === true)
+                  }
+                  count={
+                    data != null
+                      ? Object.keys(data.permissions)
+                          .map(key => data.permissions[key].found)
+                          .filter(f => f === true).length
+                      : undefined
+                  }
                   loading={loading}
-                  domRef={this.twistRefs.scripts}
+                  domRef={this.twistRefs.permissions}
+                >
+                  {data != null &&
+                    data.permissions != null && (
+                      <>
+                        {Object.keys(data.permissions).map(
+                          key =>
+                            data.permissions[key].found && (
+                              <div className="permission-entry" key={key}>
+                                <span className="permission-entry-name">
+                                  {data.permissions[key].displayName}
+                                </span>
+                                {data.permissions[key].locations.map(
+                                  location =>
+                                    location.file_name != null &&
+                                    location.start_line != null && (
+                                      <a
+                                        href={buildFindingFileLink(
+                                          repoSlug,
+                                          data.commitHash,
+                                          location.file_name,
+                                          location.start_line
+                                        )}
+                                      >
+                                        {location.file_name}:
+                                        {location.start_line}
+                                      </a>
+                                    )
+                                )}
+                              </div>
+                            )
+                        )}
+                      </>
+                    )}
+                </PreflightSection>
+              )}
+            </Fetch>
+            <Fetch<VulnsResponse> url={vulnsUrl()}>
+              {({ data, loading }) => (
+                <PreflightSection
+                  check="vulns"
+                  title="Vulnerabilities"
+                  description="Current or historical vulnerabilities discovered in this project."
+                  startOpen={data != null && data.vuln.length > 0}
+                  count={data != null ? data.vuln.length : undefined}
+                  loading={loading}
+                  domRef={this.twistRefs.vulns}
+                >
+                  {data != null &&
+                    data.vuln.map(
+                      (vulns, entriesIdx) =>
+                        vulns != null &&
+                        vulns.vuln.map(vuln => (
+                          <PreflightVulnerabilityEntry
+                            vuln={vuln}
+                            key={vuln.slug}
+                          />
+                        ))
+                    )}
+                </PreflightSection>
+              )}
+            </Fetch>
+            <Fetch<FindingsResponse> url={findingsUrlFromSlug(repoSlug)}>
+              {({ data, loading, error }) => (
+                <PreflightSection
+                  check="findings"
+                  title="Findings"
+                  description="Weaknesses or bad practices that we automatically discovered in this project."
+                  startOpen={
+                    data != null &&
+                    data.findings != null &&
+                    data.findings.length > 0
+                  }
+                  count={
+                    data != null && data.findings != null
+                      ? data.findings.length
+                      : undefined
+                  }
+                  loading={loading}
+                  domRef={this.twistRefs.findings}
+                >
+                  {data != null &&
+                    data.findings != null && (
+                      <FindingsGroupedList
+                        findings={data.findings}
+                        repoSlug={repoSlug}
+                      />
+                    )}
+                </PreflightSection>
+              )}
+            </Fetch>
+            <Fetch<PackageResponse> url={packageUrl()}>
+              {({ data, loading }) => (
+                <>
+                  <PreflightSection
+                    check="scripts"
+                    title="Install hooks"
+                    description="Hooks can run before or after installing this package, and their presence can indicate a security issue."
+                    startOpen={data != null && data.npmScripts.length > 0}
+                    count={data != null ? data.npmScripts.length : undefined}
+                    loading={loading}
+                    domRef={this.twistRefs.scripts}
+                  >
+                    {data && (
+                      <div className="install-hook">
+                        {data.npmScripts.map((script, i) => (
+                          <div key={`${script.type}_${i}`} className="hook">
+                            <span className="install-hook-type">
+                              {script.type}
+                            </span>{" "}
+                            <div className="install-hook-script">
+                              <pre>{script.script}</pre>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </PreflightSection>
+                </>
+              )}
+            </Fetch>
+            <Fetch<RepoResponse> url={repoUrl()}>
+              {({ data, loading }) => (
+                <PreflightSection
+                  check="activity"
+                  title="Commit activity"
+                  description="How long ago someone contributed to the repo. Using an inactive repo can be riskier than using a maintained one."
+                  startOpen={data != null && data.activity != null}
+                  loading={loading}
+                  domRef={this.twistRefs.activity}
                 >
                   {data && (
-                    <div className="install-hook">
-                      {data.npmScripts.map((script, i) => (
-                        <div key={`${script.type}_${i}`} className="hook">
-                          <span className="install-hook-type">
-                            {script.type}
-                          </span>{" "}
-                          <div className="install-hook-script">
-                            <pre>{script.script}</pre>
-                          </div>
-                        </div>
-                      ))}
+                    <div className="last-committed">
+                      <span className="last-committed-message">
+                        Last committed:{" "}
+                      </span>
+                      <span className="last-committed-date">
+                        {data.activity.latestCommitDate}
+                      </span>
                     </div>
                   )}
                 </PreflightSection>
-              </>
-            )}
-          </Fetch>
-          <Fetch<RepoResponse> url={repoUrl()}>
-            {({ data, loading }) => (
-              <PreflightSection
-                check="activity"
-                title="Commit activity"
-                description="How long ago someone contributed to the repo. Using an inactive repo can be riskier than using a maintained one."
-                startOpen={data != null && data.activity != null}
-                loading={loading}
-                domRef={this.twistRefs.activity}
-              >
-                {data && (
-                  <div className="last-committed">
-                    <span className="last-committed-message">
-                      Last committed:{" "}
-                    </span>
-                    <span className="last-committed-date">
-                      {data.activity.latestCommitDate}
-                    </span>
-                  </div>
-                )}
-              </PreflightSection>
-            )}
-          </Fetch>
+              )}
+            </Fetch>
+          </div>
         </div>
       </div>
     );

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -1,6 +1,9 @@
 import { Button, Classes, Spinner, Tag } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import { FindingsResponse, findingsUrl } from "@r2c/extension/api/findings";
+import {
+  FindingsResponse,
+  findingsUrlFromSlug
+} from "@r2c/extension/api/findings";
 import { PackageResponse, packageUrl } from "@r2c/extension/api/package";
 import {
   PermissionsResponse,
@@ -198,24 +201,31 @@ export default class PreflightTwist extends React.PureComponent<
               </PreflightSection>
             )}
           </Fetch>
-          <Fetch<FindingsResponse>
-            url={findingsUrl(repoSlug.domain, repoSlug.org, repoSlug.repo)}
-          >
+          <Fetch<FindingsResponse> url={findingsUrlFromSlug(repoSlug)}>
             {({ data, loading, error }) => (
               <PreflightSection
                 check="findings"
                 title="Findings"
                 description="Weaknesses or bad practices that we automatically discovered in this project."
-                startOpen={data != null && data.findings.length > 0}
-                count={data != null ? data.findings.length : undefined}
+                startOpen={
+                  data != null &&
+                  data.findings != null &&
+                  data.findings.length > 0
+                }
+                count={
+                  data != null && data.findings != null
+                    ? data.findings.length
+                    : undefined
+                }
                 loading={loading}
               >
-                {data != null && (
-                  <FindingsGroupedList
-                    findings={data.findings}
-                    repoSlug={repoSlug}
-                  />
-                )}
+                {data != null &&
+                  data.findings != null && (
+                    <FindingsGroupedList
+                      findings={data.findings}
+                      repoSlug={repoSlug}
+                    />
+                  )}
               </PreflightSection>
             )}
           </Fetch>

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -107,16 +107,14 @@ export default class PreflightTwist extends React.PureComponent<
                 description="How long ago someone contributed to the repo. Using an inactive repo can be riskier than using a maintained one."
               >
                 {data && (
-                  <>
-                    <div className="last-committed">
-                      <span className="last-committed-message">
-                        Last committed:{" "}
-                      </span>
-                      <span className="last-committed-date">
-                        {data.activity.latestCommitDate}
-                      </span>
-                    </div>
-                  </>
+                  <div className="last-committed">
+                    <span className="last-committed-message">
+                      Last committed:{" "}
+                    </span>
+                    <span className="last-committed-date">
+                      {data.activity.latestCommitDate}
+                    </span>
+                  </div>
                 )}
               </PreflightSection>
             )}
@@ -128,7 +126,22 @@ export default class PreflightTwist extends React.PureComponent<
                   check="scripts"
                   title="Install hooks"
                   description="Hooks can run before or after installing this package, and their presence can indicate a security issue."
-                />
+                >
+                  {data && (
+                    <div className="install-hook">
+                      {data.npmScripts.map((script, i) => (
+                        <div key={`${script.type}_${i}`} className="hook">
+                          <span className="install-hook-type">
+                            {script.type}
+                          </span>{" "}
+                          <div className="install-hook-script">
+                            <pre>{script.script}</pre>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </PreflightSection>
                 <PreflightSection
                   check="npm-rank"
                   title="npm ranking"
@@ -143,7 +156,14 @@ export default class PreflightTwist extends React.PureComponent<
                 check="vulns"
                 title="Vulnerabilities"
                 description="Current or historical vulnerabilities discovered in this project."
-              />
+              >
+                {data &&
+                  data.vuln.map((vuln, i) => (
+                    <div className="vulns-raw" key={i}>
+                      <pre>{vuln}</pre>
+                    </div>
+                  ))}
+              </PreflightSection>
             )}
           </Fetch>
         </div>

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -1,4 +1,4 @@
-import { Button, Classes, Spinner, Tag } from "@blueprintjs/core";
+import { Button, Spinner, Tag } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import {
   FindingsResponse,
@@ -176,8 +176,9 @@ class PreflightSection extends React.PureComponent<
         ref={domRef}
       >
         <Button
-          className={classnames("preflight-section-header", Classes.FILL)}
+          className={classnames("preflight-section-header")}
           minimal={true}
+          fill={true}
           onClick={this.toggleCollapse}
           rightIcon={open ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}
         >

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -148,11 +148,7 @@ class PreflightSection extends React.PureComponent<
   };
 
   public componentDidUpdate(prevProps: PreflightSectionProps) {
-    if (
-      this.props.startOpen != null &&
-      this.props.startOpen &&
-      this.state.open == null
-    ) {
+    if (this.props.startOpen != null && this.props.startOpen) {
       this.setState({ open: true });
     }
   }
@@ -359,6 +355,7 @@ export default class PreflightTwist extends React.PureComponent<
                   {data != null &&
                     data.findings != null && (
                       <FindingsGroupedList
+                        commitHash={data.commitHash}
                         findings={data.findings}
                         repoSlug={repoSlug}
                       />

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -148,7 +148,11 @@ class PreflightSection extends React.PureComponent<
   };
 
   public componentDidUpdate(prevProps: PreflightSectionProps) {
-    if (this.props.startOpen != null && this.props.startOpen) {
+    if (
+      this.props.startOpen != null &&
+      this.props.startOpen &&
+      this.state.open == null
+    ) {
       this.setState({ open: true });
     }
   }

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -68,25 +68,32 @@ export default class PreflightTwist extends React.PureComponent<
                 {data &&
                   data.permissions != null && (
                     <>
-                      {Object.keys(data.permissions).map(key => (
-                        <div className="permission-entry" key={key}>
-                          <span className="permission-entry-name">
-                            {data.permissions[key].displayName}
-                          </span>
-                          {data.permissions[key].locations.map(location => (
-                            <a
-                              href={buildFindingFileLink(
-                                repoSlug,
-                                data.commitHash,
-                                location.file_name,
-                                location.start_line
+                      {Object.keys(data.permissions).map(
+                        key =>
+                          data.permissions[key].found && (
+                            <div className="permission-entry" key={key}>
+                              <span className="permission-entry-name">
+                                {data.permissions[key].displayName}
+                              </span>
+                              {data.permissions[key].locations.map(
+                                location =>
+                                  location.file_name != null &&
+                                  location.start_line != null && (
+                                    <a
+                                      href={buildFindingFileLink(
+                                        repoSlug,
+                                        data.commitHash,
+                                        location.file_name,
+                                        location.start_line
+                                      )}
+                                    >
+                                      {location.file_name}:{location.start_line}
+                                    </a>
+                                  )
                               )}
-                            >
-                              {location.file_name}:{location.start_line}
-                            </a>
-                          ))}
-                        </div>
-                      ))}
+                            </div>
+                          )
+                      )}
                     </>
                   )}
               </PreflightSection>

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -1,3 +1,6 @@
+import { Button, Classes, Spinner, Tag } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { FindingsResponse, findingsUrl } from "@r2c/extension/api/findings";
 import { PackageResponse, packageUrl } from "@r2c/extension/api/package";
 import {
   PermissionsResponse,
@@ -5,6 +8,7 @@ import {
 } from "@r2c/extension/api/permissions";
 import { RepoResponse, repoUrl } from "@r2c/extension/api/repo";
 import { VulnsResponse, vulnsUrl } from "@r2c/extension/api/vulns";
+import FindingsGroupedList from "@r2c/extension/content/FindingsGroupedList";
 import { buildFindingFileLink, ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import * as React from "react";
@@ -13,6 +17,7 @@ import "./PreflightTwist.css";
 
 type PreflightCheck =
   | "permissions"
+  | "findings"
   | "activity"
   | "scripts"
   | "npm-rank"
@@ -21,25 +26,85 @@ type PreflightCheck =
 interface PreflightSectionProps {
   check: PreflightCheck;
   title: string;
+  count?: number;
   description?: string;
+  loading?: boolean | null;
+  startOpen?: boolean;
 }
 
-class PreflightSection extends React.PureComponent<PreflightSectionProps> {
+interface PreflightSectionState {
+  open: boolean | undefined;
+}
+
+class PreflightSection extends React.PureComponent<
+  PreflightSectionProps,
+  PreflightSectionState
+> {
+  public state: PreflightSectionState = {
+    open: undefined
+  };
+
+  public componentDidUpdate(prevProps: PreflightSectionProps) {
+    if (
+      this.props.startOpen != null &&
+      this.props.startOpen &&
+      this.state.open == null
+    ) {
+      this.setState({ open: true });
+    }
+  }
+
   public render() {
-    const { check, title, description, children } = this.props;
+    const {
+      check,
+      title,
+      description,
+      count,
+      children,
+      loading,
+      startOpen
+    } = this.props;
+    const { open } = this.state;
 
     return (
       <section
         className={classnames("preflight-section", `preflight-${check}`)}
       >
-        <header>
-          <span className="preflight-section-title">{title}</span>
-          <p className="preflight-section-description">{description}</p>
-        </header>
-        <div className="preflight-section-body">{children}</div>
+        <Button
+          className={classnames("preflight-section-header", Classes.FILL)}
+          minimal={true}
+          onClick={this.toggleCollapse}
+          rightIcon={open ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}
+        >
+          <span className="preflight-section-header-text">
+            <span className="preflight-section-title">{title}</span>
+            {!loading &&
+              count != null && (
+                <Tag
+                  className="preflight-section-header-count"
+                  minimal={!startOpen}
+                  round={true}
+                >
+                  {count}
+                </Tag>
+              )}
+            {loading && <Spinner size={Spinner.SIZE_SMALL} />}
+          </span>
+        </Button>
+        {!loading &&
+          open != null &&
+          open && (
+            <div className="preflight-section-body">
+              <p className="preflight-section-description">{description}</p>
+              <div className="preflight-section-content">{children}</div>
+            </div>
+          )}
       </section>
     );
   }
+
+  private toggleCollapse: React.MouseEventHandler<HTMLElement> = e =>
+    this.setState({ open: !this.state.open });
 }
 
 interface PreflightTwistProps {
@@ -59,13 +124,28 @@ export default class PreflightTwist extends React.PureComponent<
         </header>
         <div className="twist-body">
           <Fetch<PermissionsResponse> url={permissionsUrl()}>
-            {({ data }) => (
+            {({ data, loading }) => (
               <PreflightSection
                 check="permissions"
                 title="Permissions"
                 description="The project's capabilities when it runs. Unexpected capabilities can indicate a security breach or malice."
+                startOpen={
+                  data != null &&
+                  data.permissions != null &&
+                  Object.keys(data.permissions)
+                    .map(key => data.permissions[key].found)
+                    .some(f => f === true)
+                }
+                count={
+                  data != null
+                    ? Object.keys(data.permissions)
+                        .map(key => data.permissions[key].found)
+                        .filter(f => f === true).length
+                    : undefined
+                }
+                loading={loading}
               >
-                {data &&
+                {data != null &&
                   data.permissions != null && (
                     <>
                       {Object.keys(data.permissions).map(
@@ -99,33 +179,56 @@ export default class PreflightTwist extends React.PureComponent<
               </PreflightSection>
             )}
           </Fetch>
-          <Fetch<RepoResponse> url={repoUrl()}>
-            {({ data }) => (
+          <Fetch<VulnsResponse> url={vulnsUrl()}>
+            {({ data, loading }) => (
               <PreflightSection
-                check="activity"
-                title="Commit activity"
-                description="How long ago someone contributed to the repo. Using an inactive repo can be riskier than using a maintained one."
+                check="vulns"
+                title="Vulnerabilities"
+                description="Current or historical vulnerabilities discovered in this project."
+                startOpen={data != null && data.vuln.length > 0}
+                count={data != null ? data.vuln.length : undefined}
+                loading={loading}
               >
-                {data && (
-                  <div className="last-committed">
-                    <span className="last-committed-message">
-                      Last committed:{" "}
-                    </span>
-                    <span className="last-committed-date">
-                      {data.activity.latestCommitDate}
-                    </span>
-                  </div>
+                {data != null &&
+                  data.vuln.map((vuln, i) => (
+                    <div className="vulns-raw" key={i}>
+                      <pre>{JSON.stringify(vuln, undefined, 2)}</pre>
+                    </div>
+                  ))}
+              </PreflightSection>
+            )}
+          </Fetch>
+          <Fetch<FindingsResponse>
+            url={findingsUrl(repoSlug.domain, repoSlug.org, repoSlug.repo)}
+          >
+            {({ data, loading, error }) => (
+              <PreflightSection
+                check="findings"
+                title="Findings"
+                description="Weaknesses or bad practices that we automatically discovered in this project."
+                startOpen={data != null && data.findings.length > 0}
+                count={data != null ? data.findings.length : undefined}
+                loading={loading}
+              >
+                {data != null && (
+                  <FindingsGroupedList
+                    findings={data.findings}
+                    repoSlug={repoSlug}
+                  />
                 )}
               </PreflightSection>
             )}
           </Fetch>
           <Fetch<PackageResponse> url={packageUrl()}>
-            {({ data }) => (
+            {({ data, loading }) => (
               <>
                 <PreflightSection
                   check="scripts"
                   title="Install hooks"
                   description="Hooks can run before or after installing this package, and their presence can indicate a security issue."
+                  startOpen={data != null && data.npmScripts.length > 0}
+                  count={data != null ? data.npmScripts.length : undefined}
+                  loading={loading}
                 >
                   {data && (
                     <div className="install-hook">
@@ -142,27 +245,28 @@ export default class PreflightTwist extends React.PureComponent<
                     </div>
                   )}
                 </PreflightSection>
-                <PreflightSection
-                  check="npm-rank"
-                  title="npm ranking"
-                  description="The popularity of this package on npm. More widely used packages may have less risk since more people have looked at them."
-                />
               </>
             )}
           </Fetch>
-          <Fetch<VulnsResponse> url={vulnsUrl()}>
-            {({ data }) => (
+          <Fetch<RepoResponse> url={repoUrl()}>
+            {({ data, loading }) => (
               <PreflightSection
-                check="vulns"
-                title="Vulnerabilities"
-                description="Current or historical vulnerabilities discovered in this project."
+                check="activity"
+                title="Commit activity"
+                description="How long ago someone contributed to the repo. Using an inactive repo can be riskier than using a maintained one."
+                startOpen={data != null && data.activity != null}
+                loading={loading}
               >
-                {data &&
-                  data.vuln.map((vuln, i) => (
-                    <div className="vulns-raw" key={i}>
-                      <pre>{vuln}</pre>
-                    </div>
-                  ))}
+                {data && (
+                  <div className="last-committed">
+                    <span className="last-committed-message">
+                      Last committed:{" "}
+                    </span>
+                    <span className="last-committed-date">
+                      {data.activity.latestCommitDate}
+                    </span>
+                  </div>
+                )}
               </PreflightSection>
             )}
           </Fetch>

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -179,16 +179,15 @@ class PreflightSection extends React.PureComponent<
         >
           <span className="preflight-section-header-text">
             <span className="preflight-section-title">{title}</span>
-            {!loading &&
-              count != null && (
-                <Tag
-                  className="preflight-section-header-count"
-                  minimal={count > 0}
-                  round={true}
-                >
-                  {count}
-                </Tag>
-              )}
+            {!loading && (
+              <Tag
+                className="preflight-section-header-count"
+                minimal={count == null || count === 0}
+                round={true}
+              >
+                {count || 0}
+              </Tag>
+            )}
             {loading && <Spinner size={Spinner.SIZE_SMALL} />}
           </span>
         </Button>

--- a/src/content/PreflightVulnerabilityEntry.css
+++ b/src/content/PreflightVulnerabilityEntry.css
@@ -1,0 +1,78 @@
+.preflight-vulnerability-entry {
+  padding: 5px;
+  border: 1px solid rgba(255, 22, 26, 0.6);
+  box-shadow: 0px 1px 2px rgba(16, 22, 26, 0.05);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.preflight-vulnerability-entry header {
+  flex: 0 0 auto;
+}
+
+.preflight-vulnerability-entry header h2 {
+  font-size: 14px;
+}
+
+.preflight-vulnerability-entry .vuln-cves {
+  display: flex;
+  flex-direction: row;
+}
+
+.preflight-vulnerability-entry .vuln-cves .vuln-cve {
+  margin-right: 1em;
+}
+
+.preflight-vulnerability-entry .vuln-cves,
+.preflight-vulnerability-entry .vuln-metadata {
+  font-size: 12px;
+  color: rgba(16, 22, 26, 0.6);
+}
+
+.preflight-vulnerability-entry .vuln-versions {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  font-size: 12px;
+}
+
+.preflight-vulnerability-entry .vuln-versions span {
+  margin-right: 1em;
+}
+
+.preflight-vulnerability-entry .vuln-body {
+  margin: 0 -5px;
+  padding: 5px;
+  margin-top: 1ex;
+  border: 1px solid rgba(16, 22, 26, 0.1);
+  border-width: 1px 0;
+  padding-top: 1ex;
+
+  box-shadow: inset 0px 1px 2px rgba(16, 22, 26, 0.1);
+  background-color: rgba(16, 22, 26, 0.02);
+}
+
+.preflight-vulnerability-entry .vuln-body section ul {
+  margin-bottom: 1ex;
+}
+
+.preflight-vulnerability-entry .vuln-body section header {
+  font-weight: 600;
+}
+
+.preflight-vulnerability-entry .vuln-body .vuln-errata dl {
+  font-size: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.preflight-vulnerability-entry .vuln-body .vuln-errata dt {
+  font-weight: 600;
+}
+
+.preflight-vulnerability-entry .vuln-show-more-button {
+  border-radius: 0;
+  margin: 5px 0 0;
+}

--- a/src/content/Twist.css
+++ b/src/content/Twist.css
@@ -18,6 +18,16 @@
   /* https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox */
   min-height: 0;
 
-  overflow-y: auto;
   overflow-x: hidden;
+  visibility: visible;
+}
+
+.twist .twist-scroll-container {
+  overflow: auto;
+  visibility: hidden;
+  margin-right: -10px;
+}
+
+.twist .twist-scroll-container:hover {
+  visibility: visible;
 }

--- a/src/content/Twist.css
+++ b/src/content/Twist.css
@@ -17,4 +17,7 @@
 
   /* https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox */
   min-height: 0;
+
+  overflow-y: auto;
+  overflow-x: hidden;
 }

--- a/src/content/Twist.tsx
+++ b/src/content/Twist.tsx
@@ -2,7 +2,7 @@ import * as classnames from "classnames";
 import * as React from "react";
 import "./Twist.css";
 
-export type TwistId = string;
+export type TwistId = "preflight" | "discussion" | "flag" | "share";
 export type TwistElement = React.ReactElement<
   TwistProps & { children: React.ReactNode }
 >;

--- a/src/content/Twists.css
+++ b/src/content/Twists.css
@@ -33,8 +33,22 @@
   background-color: #fff;
   box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.2), 0px 0px 1px rgba(0, 0, 0, 0.3);
   padding: 10px;
-  height: 80vh;
-  max-height: 720px;
+  height: 70vh;
+  max-height: 70vh;
+
+  transition: height 0.3s;
+}
+
+@media screen and (max-height: 700px) {
+  .r2c-actionbar .twist-container .twist {
+    height: 60vh;
+  }
+}
+
+@media screen and (max-height: 500px) {
+  .r2c-actionbar .twist-container .twist {
+    height: 50vh;
+  }
 }
 
 .twist h1 {

--- a/src/content/Twists.css
+++ b/src/content/Twists.css
@@ -21,11 +21,17 @@
   width: 320px;
 }
 
-.r2c-actionbar .twist-container.twists-transition-enter {
+.r2c-actionbar.actionbar-transition-enter {
   animation: 300ms twists-in both cubic-bezier(0.215, 0.61, 0.355, 1);
 }
 
-.r2c-actionbar .twist-container.twists-transition-exit {
+.r2c-actionbar.actionbar-transition-enter-done,
+.r2c-actionbar.actionbar-transition-exit-active {
+  transform: translateX(0);
+}
+
+.r2c-actionbar.actionbar-transition-exit {
+  background-color: #f00;
   animation: 300ms twists-out both cubic-bezier(0.215, 0.61, 0.355, 1);
 }
 
@@ -58,20 +64,20 @@
 
 @keyframes twists-in {
   0% {
-    margin-right: -250px;
+    transform: translateX(320px);
   }
 
   100% {
-    margin-right: 0;
+    transform: translateX(0px);
   }
 }
 
 @keyframes twists-out {
   0% {
-    margin-right: 0px;
+    transform: translateX(-320px);
   }
 
   100% {
-    margin-right: -250px;
+    transform: translateX(0);
   }
 }

--- a/src/content/Twists.tsx
+++ b/src/content/Twists.tsx
@@ -27,20 +27,19 @@ export default class Twists extends React.PureComponent<TwistsProps> {
       .map(this.renderTwist);
 
     return (
-      <div className="r2c-actionbar">
-        <div className="actionbar-actions">{actions}</div>
-        {twistToRender != null && (
-          <CSSTransition
-            in={isOpen}
-            classNames="twists-transition"
-            timeout={300}
-            mountOnEnter={true}
-            unmountOnExit={true}
-          >
-            <div className="twist-container">{twistToRender}</div>
-          </CSSTransition>
-        )}
-      </div>
+      <CSSTransition
+        in={isOpen}
+        classNames="actionbar-transition"
+        timeout={300}
+      >
+        <div className="r2c-actionbar">
+          <div className="actionbar-actions">{actions}</div>
+          {isOpen &&
+            twistToRender != null && (
+              <div className="twist-container">{twistToRender}</div>
+            )}
+        </div>
+      </CSSTransition>
     );
   }
 

--- a/src/content/github/BlobFindingsInjector.css
+++ b/src/content/github/BlobFindingsInjector.css
@@ -25,13 +25,28 @@
 }
 
 .blob-num.r2c-blob-finding-highlight .finding-highlight-marker {
-  background-color: rgb(209, 57, 19);
   width: 10px;
   height: 10px;
   border-radius: 50%;
   position: absolute;
   left: 5px;
   top: 5px;
+}
+
+.blob-num.r2c-blob-finding-highlight
+  .finding-highlight-marker.marker-commit-match {
+  background-color: rgb(209, 57, 19);
+}
+
+.blob-num.r2c-blob-finding-highlight
+  .finding-highlight-marker.marker-commit-mismatch {
+  background-color: rgba(209, 57, 19, 0.4);
+  border: 1px dotted rgb(209, 57, 19);
+}
+
+.blob-num.r2c-blob-finding-highlight
+  .finding-highlight-marker.marker-multiple-commits {
+  box-shadow: 3px 3px 0 rgba(209, 57, 19, 0.4);
 }
 
 .r2c-blob-findings-grouped-list {

--- a/src/content/github/BlobFindingsInjector.css
+++ b/src/content/github/BlobFindingsInjector.css
@@ -60,7 +60,7 @@
   display: flex;
   flex-direction: column;
   padding: 10px;
-  border: 1px solid rgba(104, 80, 21, 0.3);
+  border-bottom: 1px solid rgba(104, 80, 21, 0.3);
   background-color: rgb(255, 246, 214);
   color: rgb(104, 80, 21);
 }

--- a/src/content/github/BlobFindingsInjector.css
+++ b/src/content/github/BlobFindingsInjector.css
@@ -55,3 +55,23 @@
   overflow-y: auto;
   overflow-x: hidden;
 }
+
+.approximate-finding-notice {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  border: 1px solid rgba(104, 80, 21, 0.3);
+  background-color: rgb(255, 246, 214);
+  color: rgb(104, 80, 21);
+}
+
+.approximate-finding-notice header {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 1ex;
+}
+
+.approximate-finding-notice .notice-text {
+  font-size: 12px;
+  margin-bottom: 1ex;
+}

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -76,6 +76,9 @@ class BlobFindingHighlight extends React.PureComponent<
       repoSlug.commitHash != null &&
       findings.every(finding => finding.commitHash === repoSlug.commitHash);
 
+    const shouldOpenPopoverByDefault =
+      repoSlug.startLineHash === findings[0].startLine;
+
     return (
       <DOMInjector
         destination={findingSpan.startGutterElem}
@@ -112,6 +115,7 @@ class BlobFindingHighlight extends React.PureComponent<
             path: findings[0].fileName,
             startLine: findings[0].startLine
           })}
+          defaultIsOpen={shouldOpenPopoverByDefault}
         >
           <div className="r2c-blob-finding-highlight-hitbox">
             <div

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -4,13 +4,31 @@ import { FindingEntry } from "@r2c/extension/api/findings";
 import FindingsGroupedList from "@r2c/extension/content/FindingsGroupedList";
 import BlobMetadata from "@r2c/extension/content/github/BlobMetadata";
 import DomElementLoadedWatcher from "@r2c/extension/content/github/DomElementLoadedWatcher";
-import CommitWarningHeadsUp from "@r2c/extension/content/headsup/CommitWarningHeadsUp";
+import CommitWarningHeadsUp, {
+  CommitChooser
+} from "@r2c/extension/content/headsup/CommitWarningHeadsUp";
 import { ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import { groupBy } from "lodash";
 import * as React from "react";
 import "./BlobFindingsInjector.css";
 import DOMInjector from "./DomInjector";
+
+const ApproximateFindingNotice: React.SFC<BlobFindingsHighlighterProps> = ({
+  repoSlug,
+  findings,
+  filePath
+}) => (
+  <div className="approximate-finding-notice">
+    <header className="notice-title">Issues occurs in past commits</header>
+    <span className="notice-text">Location may be approximate</span>
+    <CommitChooser
+      repoSlug={repoSlug}
+      findings={findings}
+      filePath={filePath}
+    />
+  </div>
+);
 
 interface BlobFindingsInjectorProps {
   findings: FindingEntry[];
@@ -68,11 +86,21 @@ class BlobFindingHighlight extends React.PureComponent<
         <Popover
           className="r2c-blob-finding-highlight-wrapper"
           content={
-            <FindingsGroupedList
-              findings={findings}
-              className="r2c-blob-findings-grouped-list"
-              repoSlug={repoSlug}
-            />
+            <>
+              {!findingCommitMatch && (
+                <ApproximateFindingNotice
+                  findings={findings}
+                  repoSlug={repoSlug}
+                  commitHash={findings[0].commitHash}
+                  filePath={findings[0].fileName}
+                />
+              )}
+              <FindingsGroupedList
+                findings={findings}
+                className="r2c-blob-findings-grouped-list"
+                repoSlug={repoSlug}
+              />
+            </>
           }
           position={Position.LEFT_TOP}
           minimal={true}

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -9,8 +9,8 @@ import { ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import { groupBy } from "lodash";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import "./BlobFindingsInjector.css";
+import DOMInjector from "./DomInjector";
 
 interface BlobFindingsInjectorProps {
   findings: FindingEntry[];
@@ -54,53 +54,48 @@ class BlobFindingHighlight extends React.PureComponent<
       return null;
     }
 
-    const destination = findingSpan.startGutterElem;
-    const existingElem = destination.querySelector(
-      ".r2c-blob-finding-highlight-wrapper"
-    );
-
-    if (existingElem != null) {
-      existingElem.remove();
-    }
-
-    destination.classList.add("r2c-blob-finding-highlight");
-
     const findingCommitMatch =
       repoSlug.commitHash != null &&
       findings.every(finding => finding.commitHash === repoSlug.commitHash);
 
-    return ReactDOM.createPortal(
-      <Popover
-        className="r2c-blob-finding-highlight-wrapper"
-        content={
-          <FindingsGroupedList
-            findings={findings}
-            className="r2c-blob-findings-grouped-list"
-            repoSlug={repoSlug}
-          />
-        }
-        position={Position.LEFT_TOP}
-        minimal={true}
-        modifiers={{
-          preventOverflow: { boundariesElement: "viewport" },
-          offset: { offset: "0px,40px" }
-        }}
-        onOpened={l("blob-finding-highlight-click", undefined, {
-          path: findings[0].fileName,
-          startLine: findings[0].startLine
-        })}
+    return (
+      <DOMInjector
+        destination={findingSpan.startGutterElem}
+        childClassName="r2c-blob-finding-highlight-wrapper"
+        injectedClassName="r2c-blob-finding-highlight"
+        relation="direct"
       >
-        <div className="r2c-blob-finding-highlight-hitbox">
-          <div
-            className={classnames("finding-highlight-marker", {
-              "marker-commit-match": findingCommitMatch,
-              "marker-commit-mismatch": !findingCommitMatch,
-              "marker-multiple-commits": findings.length > 1
-            })}
-          />
-        </div>
-      </Popover>,
-      destination
+        <Popover
+          className="r2c-blob-finding-highlight-wrapper"
+          content={
+            <FindingsGroupedList
+              findings={findings}
+              className="r2c-blob-findings-grouped-list"
+              repoSlug={repoSlug}
+            />
+          }
+          position={Position.LEFT_TOP}
+          minimal={true}
+          modifiers={{
+            preventOverflow: { boundariesElement: "viewport" },
+            offset: { offset: "0px,40px" }
+          }}
+          onOpened={l("blob-finding-highlight-click", undefined, {
+            path: findings[0].fileName,
+            startLine: findings[0].startLine
+          })}
+        >
+          <div className="r2c-blob-finding-highlight-hitbox">
+            <div
+              className={classnames("finding-highlight-marker", {
+                "marker-commit-match": findingCommitMatch,
+                "marker-commit-mismatch": !findingCommitMatch,
+                "marker-multiple-commits": findings.length > 1
+              })}
+            />
+          </div>
+        </Popover>
+      </DOMInjector>
     );
   }
 

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -26,6 +26,7 @@ const ApproximateFindingNotice: React.SFC<BlobFindingsHighlighterProps> = ({
       repoSlug={repoSlug}
       findings={findings}
       filePath={filePath}
+      inlineFinding={true}
     />
   </div>
 );

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -33,19 +33,22 @@ const ApproximateFindingNotice: React.SFC<BlobFindingsHighlighterProps> = ({
 
 interface BlobFindingsInjectorProps {
   findings: FindingEntry[];
+  findingCommitHash: string;
   repoSlug: ExtractedRepoSlug;
 }
 
 interface BlobFindingsHighlighterProps extends BlobFindingsInjectorProps {
   filePath: string;
-  commitHash: string | null;
+  findingCommitHash: string;
+  pageCommitHash: string | null;
   repoSlug: ExtractedRepoSlug;
 }
 
 interface BlobFindingDetailsProps {
   findings: FindingEntry[];
   repoSlug: ExtractedRepoSlug;
-  currentCommitHash: string | null;
+  findingCommitHash: string;
+  pageCommitHash: string | null;
 }
 
 interface FindingSpan {
@@ -65,7 +68,7 @@ class BlobFindingHighlight extends React.PureComponent<
   BlobFindingDetailsProps
 > {
   public render() {
-    const { findings, repoSlug } = this.props;
+    const { findings, repoSlug, findingCommitHash } = this.props;
 
     const findingSpan = this.computeFindingSpan(findings[0]);
 
@@ -93,13 +96,15 @@ class BlobFindingHighlight extends React.PureComponent<
             <>
               {!findingCommitMatch && (
                 <ApproximateFindingNotice
+                  findingCommitHash={findingCommitHash}
                   findings={findings}
                   repoSlug={repoSlug}
-                  commitHash={findings[0].commitHash}
+                  pageCommitHash={findingCommitHash}
                   filePath={findings[0].fileName}
                 />
               )}
               <FindingsGroupedList
+                commitHash={findingCommitHash}
                 findings={findings}
                 className="r2c-blob-findings-grouped-list"
                 repoSlug={repoSlug}
@@ -202,7 +207,8 @@ class BlobFindingsHighlighter extends React.PureComponent<
     return Object.keys(groupedByStartLine).map((startLine, i) => (
       <BlobFindingHighlight
         key={i}
-        currentCommitHash={this.props.commitHash}
+        findingCommitHash={this.props.findingCommitHash}
+        pageCommitHash={this.props.pageCommitHash}
         findings={groupedByStartLine[startLine]}
         repoSlug={this.props.repoSlug}
       />
@@ -214,7 +220,7 @@ export default class BlobFindingsInjector extends React.PureComponent<
   BlobFindingsInjectorProps
 > {
   public render() {
-    const { repoSlug } = this.props;
+    const { repoSlug, findingCommitHash } = this.props;
 
     return (
       <DomElementLoadedWatcher
@@ -231,7 +237,8 @@ export default class BlobFindingsInjector extends React.PureComponent<
                   <>
                     <BlobFindingsHighlighter
                       filePath={filePath}
-                      commitHash={commitHash}
+                      findingCommitHash={findingCommitHash}
+                      pageCommitHash={commitHash}
                       findings={this.props.findings}
                       repoSlug={repoSlug}
                     />

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -177,7 +177,7 @@ class BlobFindingsHighlighter extends React.PureComponent<
   }
 }
 
-export default class BlobFindingsInjector extends React.Component<
+export default class BlobFindingsInjector extends React.PureComponent<
   BlobFindingsInjectorProps
 > {
   public render() {

--- a/src/content/github/DomInjector.tsx
+++ b/src/content/github/DomInjector.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+interface DOMInjectorProps {
+  injectedClassName: string;
+  destinationClassName: string;
+  position?: "before" | "after";
+}
+
+export default class DOMInjector extends React.PureComponent<DOMInjectorProps> {
+  public render() {
+    const {
+      children,
+      injectedClassName,
+      destinationClassName,
+      position
+    } = this.props;
+    const destination = document.querySelector(`.${destinationClassName}`);
+    const existingElem = document.querySelector(`.${injectedClassName}`);
+
+    if (destination == null) {
+      return null;
+    }
+
+    if (existingElem != null) {
+      existingElem.remove();
+    }
+
+    const injected = document.createElement("div");
+    injected.classList.add(injectedClassName);
+
+    if (position == null || position === "after") {
+      destination.after(injected);
+    } else if (position === "before") {
+      destination.before(injected);
+    }
+
+    return ReactDOM.createPortal(children, injected);
+  }
+}

--- a/src/content/github/DomInjector.tsx
+++ b/src/content/github/DomInjector.tsx
@@ -2,23 +2,47 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 interface DOMInjectorProps {
-  injectedClassName: string;
-  destinationClassName: string;
-  position?: "before" | "after";
+  /**
+   * The classname of the child being injected
+   */
+  childClassName: string;
+
+  /**
+   * The site to inject the child into
+   */
+  destination: string | Element;
+
+  /**
+   * After injection, add this classname to the destination node
+   */
+  injectedClassName?: string;
+
+  /**
+   * Where to inject the child in relation to the destination
+   *
+   * "before": as a sibling, before the destination node
+   * "after": as a sibling, after the destination node
+   * "prependchild": as a child, as the last child of the destination node
+   * "appendchild": as a child, as the first child of the destination node
+   * "direct": use ReactDOM.createPortal semantics in the destination node
+   */
+  relation?: "before" | "after" | "prependchild" | "appendchild" | "direct";
 }
 
 export default class DOMInjector extends React.PureComponent<DOMInjectorProps> {
   public render() {
     const {
       children,
+      childClassName,
+      destination,
       injectedClassName,
-      destinationClassName,
-      position
+      relation
     } = this.props;
-    const destination = document.querySelector(`.${destinationClassName}`);
-    const existingElem = document.querySelector(`.${injectedClassName}`);
 
-    if (destination == null) {
+    const site = this.getElementForDestination(destination);
+    const existingElem = document.querySelector(`.${childClassName}`);
+
+    if (site == null) {
       return null;
     }
 
@@ -26,15 +50,43 @@ export default class DOMInjector extends React.PureComponent<DOMInjectorProps> {
       existingElem.remove();
     }
 
-    const injected = document.createElement("div");
-    injected.classList.add(injectedClassName);
+    if (injectedClassName != null) {
+      site.classList.add(injectedClassName);
+    }
 
-    if (position == null || position === "after") {
-      destination.after(injected);
-    } else if (position === "before") {
-      destination.before(injected);
+    if (relation === "direct") {
+      return ReactDOM.createPortal(children, site);
+    }
+
+    const injected = document.createElement("div");
+    injected.classList.add(childClassName);
+
+    switch (relation) {
+      case "after":
+      case null:
+        site.after(injected);
+        break;
+      case "before":
+        site.before(injected);
+        break;
+      case "prependchild":
+        site.prepend(injected);
+        break;
+      case "appendchild":
+      default:
+        site.appendChild(injected);
     }
 
     return ReactDOM.createPortal(children, injected);
   }
+
+  private getElementForDestination = (
+    destination: string | Element
+  ): Element | null => {
+    if (typeof destination === "string") {
+      return document.querySelector(destination);
+    } else {
+      return destination;
+    }
+  };
 }

--- a/src/content/github/DomInjector.tsx
+++ b/src/content/github/DomInjector.tsx
@@ -40,11 +40,12 @@ export default class DOMInjector extends React.PureComponent<DOMInjectorProps> {
     } = this.props;
 
     const site = this.getElementForDestination(destination);
-    const existingElem = document.querySelector(`.${childClassName}`);
 
-    if (site == null) {
+    if (site == null || site.parentElement == null) {
       return null;
     }
+
+    const existingElem = site.parentElement.querySelector(`.${childClassName}`);
 
     if (existingElem != null) {
       existingElem.remove();
@@ -58,7 +59,7 @@ export default class DOMInjector extends React.PureComponent<DOMInjectorProps> {
       return ReactDOM.createPortal(children, site);
     }
 
-    const injected = document.createElement("div");
+    const injected = document.createElement("span");
     injected.classList.add(childClassName);
 
     switch (relation) {

--- a/src/content/github/TreeFindingsInjector.tsx
+++ b/src/content/github/TreeFindingsInjector.tsx
@@ -11,6 +11,7 @@ import "./TreeFindingsInjector.css";
 
 interface TreeFindingsInjectorProps {
   findings: FindingEntry[];
+  commitHash: string;
   repoSlug: ExtractedRepoSlug;
 }
 
@@ -20,6 +21,7 @@ interface TreeFindingsHighlighterProps extends TreeFindingsInjectorProps {
 
 interface TreeFindingHighlightProps {
   findings: FindingEntry[];
+  commitHash: string;
   path: string;
 }
 
@@ -27,7 +29,7 @@ class TreeFindingHighlight extends React.PureComponent<
   TreeFindingHighlightProps
 > {
   public render() {
-    const { findings, path } = this.props;
+    const { findings, commitHash, path } = this.props;
 
     return (
       <DOMInjector
@@ -41,6 +43,7 @@ class TreeFindingHighlight extends React.PureComponent<
           content={
             <FindingsGroupedList
               findings={findings}
+              commitHash={commitHash}
               className="r2c-tree-findings-grouped-list"
             />
           }
@@ -66,7 +69,7 @@ class TreeFindingsHighlighter extends React.PureComponent<
   TreeFindingsHighlighterProps
 > {
   public render() {
-    const { currentPath, findings } = this.props;
+    const { currentPath, findings, commitHash } = this.props;
 
     const filtered = findings.filter(finding =>
       finding.fileName.startsWith(currentPath)
@@ -90,6 +93,7 @@ class TreeFindingsHighlighter extends React.PureComponent<
         {[...immediatePathChildren.values()].map(directoryEntry => (
           <TreeFindingHighlight
             key={directoryEntry}
+            commitHash={commitHash}
             findings={filtered.filter(finding =>
               finding.fileName
                 .slice(currentPath.length)
@@ -119,6 +123,7 @@ export default class TreeFindingsInjector extends React.PureComponent<
                   <TreeFindingsHighlighter
                     currentPath={currentPath}
                     findings={this.props.findings}
+                    commitHash={this.props.commitHash}
                     repoSlug={this.props.repoSlug}
                   />
                 )}

--- a/src/content/github/TreeFindingsInjector.tsx
+++ b/src/content/github/TreeFindingsInjector.tsx
@@ -6,7 +6,7 @@ import DomElementLoadedWatcher from "@r2c/extension/content/github/DomElementLoa
 import TreeMetadata from "@r2c/extension/content/github/TreeMetadata";
 import { ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import DOMInjector from "./DomInjector";
 import "./TreeFindingsInjector.css";
 
 interface TreeFindingsInjectorProps {
@@ -29,49 +29,34 @@ class TreeFindingHighlight extends React.PureComponent<
   public render() {
     const { findings, path } = this.props;
 
-    const pathElem = document.querySelector(
-      `a[title='${path}'].js-navigation-open`
-    );
-
-    if (pathElem == null || pathElem.parentElement == null) {
-      return null;
-    }
-
-    const destination = pathElem.parentElement;
-    const existingElem = destination.querySelector(
-      ".r2c-tree-finding-highlight-wrapper"
-    );
-
-    if (existingElem != null) {
-      // HACK: GitHub uses pjax for navigation, which can save a snapshot of the DOM before
-      // React has a chance to unmount the portal. If we find a previous portal, let's get rid
-      // of it before mounting a new one.
-      existingElem.remove();
-    }
-
-    return ReactDOM.createPortal(
-      <Popover
-        className="r2c-tree-finding-highlight-wrapper"
-        content={
-          <FindingsGroupedList
-            findings={findings}
-            className="r2c-tree-findings-grouped-list"
-          />
-        }
-        position={Position.LEFT_TOP}
-        minimal={true}
-        modifiers={{
-          preventOverflow: { boundariesElement: "viewport" },
-          offset: { offset: "0px,40px" }
-        }}
-        onOpened={l("tree-finding-highlight-click", undefined, { path })}
+    return (
+      <DOMInjector
+        destination={`a[title='${path}'].js-navigation-open`}
+        childClassName="r2c-tree-finding-highlight-popover"
+        relation="direct"
       >
-        <span className="r2c-tree-finding-highlight-marker">
-          <span className="r2c-tree-finding-count">{findings.length}</span>{" "}
-          {`issue${findings.length === 1 ? "" : "s"}`}
-        </span>
-      </Popover>,
-      destination
+        <Popover
+          className="r2c-tree-finding-highlight-popover"
+          content={
+            <FindingsGroupedList
+              findings={findings}
+              className="r2c-tree-findings-grouped-list"
+            />
+          }
+          position={Position.LEFT_TOP}
+          minimal={true}
+          modifiers={{
+            preventOverflow: { boundariesElement: "viewport" },
+            offset: { offset: "0px,40px" }
+          }}
+          onOpened={l("tree-finding-highlight-click", undefined, { path })}
+        >
+          <span className="r2c-tree-finding-highlight-marker">
+            <span className="r2c-tree-finding-count">{findings.length}</span>{" "}
+            {`issue${findings.length === 1 ? "" : "s"}`}
+          </span>
+        </Popover>
+      </DOMInjector>
     );
   }
 }

--- a/src/content/github/TreeFindingsInjector.tsx
+++ b/src/content/github/TreeFindingsInjector.tsx
@@ -33,7 +33,8 @@ class TreeFindingHighlight extends React.PureComponent<
       <DOMInjector
         destination={`a[title='${path}'].js-navigation-open`}
         childClassName="r2c-tree-finding-highlight-popover"
-        relation="direct"
+        injectedClassName="r2c-tree-finding-highlight"
+        relation="after"
       >
         <Popover
           className="r2c-tree-finding-highlight-popover"
@@ -102,7 +103,7 @@ class TreeFindingsHighlighter extends React.PureComponent<
   }
 }
 
-export default class TreeFindingsInjector extends React.Component<
+export default class TreeFindingsInjector extends React.PureComponent<
   TreeFindingsInjectorProps
 > {
   public render() {

--- a/src/content/headsup/CommitWarningHeadsUp.css
+++ b/src/content/headsup/CommitWarningHeadsUp.css
@@ -9,3 +9,11 @@
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
     monospace;
 }
+
+.commit-warning-headsup .headsup-different-commit {
+  margin-right: 2em;
+}
+
+.commit-warning-headsup .past-commit-action-button {
+  flex: 0 0 auto;
+}

--- a/src/content/headsup/CommitWarningHeadsUp.css
+++ b/src/content/headsup/CommitWarningHeadsUp.css
@@ -4,3 +4,8 @@
   background-color: rgb(255, 246, 214);
   color: rgb(104, 80, 21);
 }
+
+.commit-hash-select-menu .commit-hash-entry .bp3-text-overflow-ellipsis {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
+    monospace;
+}

--- a/src/content/headsup/CommitWarningHeadsUp.css
+++ b/src/content/headsup/CommitWarningHeadsUp.css
@@ -1,0 +1,6 @@
+.commit-warning-headsup {
+  margin-bottom: 1ex;
+  border-color: rgba(104, 80, 21, 0.3);
+  background-color: rgb(255, 246, 214);
+  color: rgb(104, 80, 21);
+}

--- a/src/content/headsup/CommitWarningHeadsUp.tsx
+++ b/src/content/headsup/CommitWarningHeadsUp.tsx
@@ -60,6 +60,7 @@ export class CommitChooser extends React.PureComponent<CommitChooserProps> {
           )}
           intent={Intent.SUCCESS}
           onClick={l("commit-warning-action-click")}
+          className="past-commit-action-button"
         >
           Go to past commit
         </AnchorButton>

--- a/src/content/headsup/CommitWarningHeadsUp.tsx
+++ b/src/content/headsup/CommitWarningHeadsUp.tsx
@@ -1,0 +1,146 @@
+import {
+  AnchorButton,
+  Button,
+  Intent,
+  MenuItem,
+  Position
+} from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { ItemRenderer, Select } from "@blueprintjs/select";
+import { FindingEntry } from "@r2c/extension/api/findings";
+import DOMInjector from "@r2c/extension/content/github/DomInjector";
+import { buildFindingFileLink, ExtractedRepoSlug } from "@r2c/extension/utils";
+import * as React from "react";
+import "./CommitWarningHeadsUp.css";
+
+interface CommitWarningHeadsUpProps {
+  repoSlug: ExtractedRepoSlug;
+  findings: FindingEntry[];
+  currentCommitHash: string | null;
+  filePath: string;
+}
+
+const CommitSelect = Select.ofType<string>();
+
+export default class CommitWarningHeadsUp extends React.PureComponent<
+  CommitWarningHeadsUpProps
+> {
+  public render() {
+    return (
+      <DOMInjector
+        destinationClassName="file-navigation"
+        injectedClassName="r2c-repo-headsup-container"
+        position="before"
+      >
+        {this.renderInjected()}
+      </DOMInjector>
+    );
+  }
+
+  private renderInjected() {
+    const { repoSlug, filePath, findings } = this.props;
+    const commitHashes = new Set(findings
+      .map(finding => finding.commitHash)
+      .filter(f => f) as string[]);
+
+    if (findings.length === 0) {
+      return (
+        <div className="r2c-repo-headsup commit-warning-headsup">
+          DEBUG: No findings for the current file
+        </div>
+      );
+    }
+
+    if (commitHashes.size === 0) {
+      return (
+        <div className="r2c-repo-headsup commit-warning-headsup">
+          DEBUG: No findings with commit hashes
+        </div>
+      );
+    }
+
+    if (
+      repoSlug.seemsLikeCommitHash &&
+      repoSlug.commitHash != null &&
+      commitHashes.has(repoSlug.commitHash) &&
+      commitHashes.size === 1
+    ) {
+      return (
+        <div className="r2c-repo-headsup commit-warning-headsup">
+          DEBUG: Commit hash matches all known findings
+        </div>
+      );
+    }
+
+    const commitHashList = Array.from(commitHashes);
+
+    return (
+      <div className="r2c-repo-headsup commit-warning-headsup">
+        <div className="headsup-inline-message">
+          <span className="headsup-different-commit">
+            We're also showing you issues that we found in past commits.
+          </span>
+          {commitHashList.length === 1 && (
+            <AnchorButton
+              href={buildFindingFileLink(
+                repoSlug,
+                commitHashList[0],
+                filePath,
+                null
+              )}
+              intent={Intent.SUCCESS}
+            >
+              Go to past commit
+            </AnchorButton>
+          )}
+          {commitHashList.length > 1 && (
+            <CommitSelect
+              items={commitHashList}
+              itemRenderer={this.renderCommitHashEntry}
+              onItemSelect={this.handleCommitHashSelect}
+              popoverProps={{
+                position: Position.BOTTOM_LEFT,
+                minimal: true,
+                popoverClassName: "commit-hash-select-menu",
+                className: "commit-hash-select-dropdown-wrapper",
+                targetClassName: "commit-hash-select-dropdown-target"
+              }}
+            >
+              <Button
+                className="commit-hash-select-dropdown-button"
+                rightIcon={IconNames.CARET_DOWN}
+                minimal={true}
+                text="Choose another..."
+                intent={Intent.PRIMARY}
+              />
+            </CommitSelect>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  private renderCommitHashEntry: ItemRenderer<string> = (
+    commitHash,
+    { handleClick, modifiers, query }
+  ) => (
+    <MenuItem
+      active={modifiers.active}
+      disabled={modifiers.disabled}
+      key={commitHash}
+      onClick={handleClick}
+      text={commitHash}
+    />
+  );
+
+  private handleCommitHashSelect = (commitHash: string) => {
+    const { repoSlug, filePath } = this.props;
+
+    window.location.href = buildFindingFileLink(
+      repoSlug,
+      commitHash,
+      filePath,
+      null
+    );
+  };
+}

--- a/src/content/headsup/CommitWarningHeadsUp.tsx
+++ b/src/content/headsup/CommitWarningHeadsUp.tsx
@@ -34,11 +34,12 @@ interface CommitChooserProps {
   repoSlug: ExtractedRepoSlug;
   filePath: string;
   findings: FindingEntry[];
+  inlineFinding?: boolean;
 }
 
 export class CommitChooser extends React.PureComponent<CommitChooserProps> {
   public render() {
-    const { findings, repoSlug, filePath } = this.props;
+    const { findings, repoSlug, filePath, inlineFinding } = this.props;
 
     const commitHashList = groupBy(
       findings,
@@ -55,7 +56,7 @@ export class CommitChooser extends React.PureComponent<CommitChooserProps> {
             repoSlug,
             commitGroups[0].commitHash,
             filePath,
-            null
+            inlineFinding ? findings[0].startLine : null
           )}
           intent={Intent.SUCCESS}
           onClick={l("commit-warning-action-click")}
@@ -107,13 +108,13 @@ export class CommitChooser extends React.PureComponent<CommitChooserProps> {
   );
 
   private handleCommitHashSelect = (commitHashGroup: CommitFindingGroup) => {
-    const { repoSlug, filePath } = this.props;
+    const { repoSlug, filePath, findings, inlineFinding } = this.props;
 
     window.location.href = buildFindingFileLink(
       repoSlug,
       commitHashGroup.commitHash,
       filePath,
-      null
+      inlineFinding ? findings[0].startLine : null
     );
   };
 }

--- a/src/content/headsup/CommitWarningHeadsUp.tsx
+++ b/src/content/headsup/CommitWarningHeadsUp.tsx
@@ -35,9 +35,9 @@ export default class CommitWarningHeadsUp extends React.PureComponent<
   public render() {
     return (
       <DOMInjector
-        destinationClassName="file-navigation"
-        injectedClassName="r2c-repo-headsup-container"
-        position="before"
+        destination=".file-navigation"
+        childClassName="r2c-repo-headsup-container"
+        relation="before"
       >
         {this.renderInjected()}
       </DOMInjector>

--- a/src/content/headsup/NonIdealHeadsup.css
+++ b/src/content/headsup/NonIdealHeadsup.css
@@ -2,3 +2,13 @@
   display: flex;
   align-items: center;
 }
+
+.error-headsup .error-message-details {
+  align-self: flex-end;
+}
+
+.error-headsup .error-message-raw {
+  margin-top: 1em;
+
+  background-color: rgba(16, 22, 26, 0.1);
+}

--- a/src/content/headsup/NonIdealHeadsup.tsx
+++ b/src/content/headsup/NonIdealHeadsup.tsx
@@ -68,32 +68,50 @@ interface ErrorHeadsUpProps {
   error: React.ErrorInfo | Error;
 }
 
-export class ErrorHeadsUp extends React.PureComponent<ErrorHeadsUpProps> {
-  public state: UnsupportedMessageState = {
-    closed: false
+interface ErrorHeadsUpState {
+  showDetails: boolean;
+}
+
+export class ErrorHeadsUp extends React.PureComponent<
+  ErrorHeadsUpProps,
+  ErrorHeadsUpState
+> {
+  public state: ErrorHeadsUpState = {
+    showDetails: false
   };
 
   public render() {
-    if (this.state.closed) {
-      return null;
-    }
-
     return (
-      <div className="r2c-repo-headsup error-headsup">
+      <div className="r2c-repo-headsup errror-headsup">
         <div className="error-message">
           <Icon
             icon={IconNames.WARNING_SIGN}
             className="error-icon"
             intent={Intent.DANGER}
           />
-          <span className="error-message-text">Couldn't load Preflight</span>
-          <span className="error-message-details">
-            {JSON.stringify(this.props.error)}
-          </span>
+          <div className="error-message-text">Couldn't load Preflight</div>
+          <div className="error-message-details">
+            <Button
+              onClick={this.handleToggleShowDetails}
+              minimal={true}
+              small={true}
+              className="error-message-show-more"
+            >
+              Show {this.state.showDetails ? "less" : "more"}
+            </Button>
+            {this.state.showDetails && (
+              <pre className="error-message-raw">
+                {JSON.stringify(this.props.error)}
+              </pre>
+            )}
+          </div>
         </div>
       </div>
     );
   }
+
+  private handleToggleShowDetails: React.MouseEventHandler<HTMLElement> = e =>
+    this.setState({ showDetails: !this.state.showDetails });
 }
 
 export class LoadingHeadsUp extends React.PureComponent {

--- a/src/content/headsup/PreflightChecklist.tsx
+++ b/src/content/headsup/PreflightChecklist.tsx
@@ -300,9 +300,7 @@ const PreflightFindingsItem: React.SFC<PreflightFindingsItemProps> = ({
         itemType="findings"
         onChecklistItemClick={onChecklistItemClick}
       >
-        <span className="preflight-checklist-title">
-          Unable to get findings
-        </span>
+        Unable to get findings
       </PreflightChecklistItem>
     );
   } else if (findings.length === 0) {
@@ -312,7 +310,7 @@ const PreflightFindingsItem: React.SFC<PreflightFindingsItemProps> = ({
         itemType="findings"
         onChecklistItemClick={onChecklistItemClick}
       >
-        <span className="preflight-checklist-title">No issues to report</span>
+        No issues to report
       </PreflightChecklistItem>
     );
   } else {

--- a/src/content/headsup/PreflightChecklist.tsx
+++ b/src/content/headsup/PreflightChecklist.tsx
@@ -76,11 +76,11 @@ const PreflightChecklistItem: React.SFC<PreflightChecklistItemProps> = ({
     className={classnames(
       "preflight-checklist-item",
       `${itemType}-checklist-item`,
-      Classes.FILL,
       { [Classes.SKELETON]: loading }
     )}
     onClick={onChecklistItemClick(itemType)}
     minimal={true}
+    fill={true}
   >
     <span className="preflight-checklist-title">{children}</span>
   </Button>

--- a/src/content/headsup/index.css
+++ b/src/content/headsup/index.css
@@ -93,7 +93,8 @@ ul.preflight-checklist .preflight-checklist-item .preflight-checklist-title {
   align-items: center;
 }
 
-.unsupported-headsup .unsupported-message {
+.unsupported-headsup .unsupported-message,
+.r2c-repo-headsup .headsup-inline-message {
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/content/headsup/index.css
+++ b/src/content/headsup/index.css
@@ -9,7 +9,7 @@
 }
 
 .r2c-repo-headsup > header {
-  margin-bottom: 1em;
+  margin-bottom: 1ex;
 
   display: flex;
   flex-direction: row;
@@ -52,7 +52,7 @@ ul.preflight-checklist .preflight-checklist-item {
   display: flex;
   justify-content: flex-start;
   flex-wrap: wrap;
-  margin-bottom: 1ex;
+  margin-left: -10px;
 }
 
 ul.preflight-checklist .preflight-checklist-item .preflight-checklist-icon {

--- a/src/content/headsup/index.tsx
+++ b/src/content/headsup/index.tsx
@@ -54,7 +54,7 @@ class NormalHeadsUp extends React.PureComponent<{}, HeadsupState> {
                 </header>
                 <div className="repo-headsup-body">
                   <div className="repo-headsup-checklist">
-                    <PreflightChecklist repo={data.repo} pkg={data.pkg} />
+                    <PreflightChecklist {...data} />
                   </div>
                   <div className="repo-headsup-actions">
                     <RepoPackageSection />

--- a/src/content/headsup/index.tsx
+++ b/src/content/headsup/index.tsx
@@ -9,7 +9,8 @@ import {
 } from "@r2c/extension/content/headsup/NonIdealHeadsup";
 import {
   PreflightChecklist,
-  PreflightChecklistFetch
+  PreflightChecklistFetch,
+  PreflightChecklistItemType
 } from "@r2c/extension/content/headsup/PreflightChecklist";
 import UsedBy from "@r2c/extension/content/headsup/UsedBy";
 import RepoPackageSection from "@r2c/extension/content/PackageCopyBox";
@@ -18,11 +19,17 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import "./index.css";
 
+interface HeadsUpProps {
+  onChecklistItemClick(
+    itemType: PreflightChecklistItemType
+  ): React.MouseEventHandler<HTMLElement>;
+}
+
 interface HeadsupState {
   closed: boolean;
 }
 
-class NormalHeadsUp extends React.PureComponent<{}, HeadsupState> {
+class NormalHeadsUp extends React.PureComponent<HeadsUpProps, HeadsupState> {
   public state: HeadsupState = {
     closed: false
   };
@@ -54,7 +61,10 @@ class NormalHeadsUp extends React.PureComponent<{}, HeadsupState> {
                 </header>
                 <div className="repo-headsup-body">
                   <div className="repo-headsup-checklist">
-                    <PreflightChecklist {...data} />
+                    <PreflightChecklist
+                      {...data}
+                      onChecklistItemClick={this.props.onChecklistItemClick}
+                    />
                   </div>
                   <div className="repo-headsup-actions">
                     <RepoPackageSection />
@@ -104,7 +114,7 @@ interface RepoHeadsUpState {
   error: React.ErrorInfo | undefined;
 }
 
-class RepoHeadsUp extends React.PureComponent<{}, RepoHeadsUpState> {
+class RepoHeadsUp extends React.PureComponent<HeadsUpProps, RepoHeadsUpState> {
   public state: RepoHeadsUpState = {
     error: undefined
   };
@@ -132,18 +142,20 @@ class RepoHeadsUp extends React.PureComponent<{}, RepoHeadsUpState> {
     return ReactDOM.createPortal(
       <div className="preflight-container">
         {this.state.error != null && <ErrorHeadsUp error={this.state.error} />}
-        {this.state.error == null && <NormalHeadsUp />}
+        {this.state.error == null && <NormalHeadsUp {...this.props} />}
       </div>,
       injected
     );
   }
 }
 
-export default class RepoHeadsUpInjector extends React.PureComponent {
+export default class RepoHeadsUpInjector extends React.PureComponent<
+  HeadsUpProps
+> {
   public render() {
     return (
       <DomElementLoadedWatcher querySelector=".repository-lang-stats-graph">
-        {({ done }) => done && <RepoHeadsUp />}
+        {({ done }) => done && <RepoHeadsUp {...this.props} />}
       </DomElementLoadedWatcher>
     );
   }

--- a/src/content/headsup/index.tsx
+++ b/src/content/headsup/index.tsx
@@ -2,16 +2,8 @@ import { Button, Icon, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { l } from "@r2c/extension/analytics";
 import DomElementLoadedWatcher from "@r2c/extension/content/github/DomElementLoadedWatcher";
-import {
-  ErrorHeadsUp,
-  LoadingHeadsUp,
-  UnsupportedHeadsUp
-} from "@r2c/extension/content/headsup/NonIdealHeadsup";
-import {
-  PreflightChecklist,
-  PreflightChecklistFetch,
-  PreflightChecklistItemType
-} from "@r2c/extension/content/headsup/PreflightChecklist";
+import { ErrorHeadsUp, LoadingHeadsUp, UnsupportedHeadsUp } from "@r2c/extension/content/headsup/NonIdealHeadsup";
+import { PreflightChecklist, PreflightChecklistFetch, PreflightChecklistItemType } from "@r2c/extension/content/headsup/PreflightChecklist";
 import UsedBy from "@r2c/extension/content/headsup/UsedBy";
 import RepoPackageSection from "@r2c/extension/content/PackageCopyBox";
 import { R2CLogo } from "@r2c/extension/icons";
@@ -47,8 +39,8 @@ class NormalHeadsUp extends React.PureComponent<HeadsUpProps, HeadsupState> {
             {response != null &&
               response.repo.status === 404 && <UnsupportedHeadsUp />}
             {error &&
-              response != null &&
-              response.repo.status !== 404 && <ErrorHeadsUp error={error} />}
+              (response == null ||
+              response.repo.status !== 404) && <ErrorHeadsUp error={error} />}
             {data && (
               <div className="r2c-repo-headsup checklist-headsup">
                 <header>

--- a/src/content/index.css
+++ b/src/content/index.css
@@ -15,10 +15,10 @@
 
 @keyframes extension-in {
   0% {
-    right: -144px;
+    transform: translateX(144px);
   }
 
   100% {
-    right: 0;
+    transform: translateX(0);
   }
 }

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -6,7 +6,10 @@ import {
   extractCurrentUserFromPage,
   getAnalyticsParams
 } from "@r2c/extension/api/fetch";
-import { FindingsResponse, findingsUrl } from "@r2c/extension/api/findings";
+import {
+  FindingsResponse,
+  findingsUrlFromSlug
+} from "@r2c/extension/api/findings";
 import {
   buildVotingUrl,
   DEPRECATED_submitVote,
@@ -116,13 +119,7 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
             }`}
           />
           {this.repoSlug != null && (
-            <Fetch<FindingsResponse>
-              url={findingsUrl(
-                this.repoSlug.domain,
-                this.repoSlug.org,
-                this.repoSlug.repo
-              )}
-            >
+            <Fetch<FindingsResponse> url={findingsUrlFromSlug(this.repoSlug)}>
               {({
                 data: findingsData,
                 loading: findingsLoading,
@@ -130,7 +127,8 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
               }) =>
                 extensionState != null &&
                 extensionState.experiments.recon &&
-                findingsData != null && (
+                findingsData != null &&
+                findingsData.findings != null && (
                   <>
                     <BlobFindingsInjector
                       key={`BlobFindingsInjector ${this.state.currentUrl} ${

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -125,6 +125,7 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
                     <BlobFindingsInjector
                       key={`BlobFindingsInjector ${this.state.currentUrl}`}
                       findings={findingsData.findings}
+                      repoSlug={repoSlug}
                     />
                     <TreeFindingsInjector
                       key={`TreeFindingsInjector ${this.state.currentUrl}`}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -21,7 +21,7 @@ import BlobFindingsInjector from "@r2c/extension/content/github/BlobFindingsInje
 import TreeFindingsInjector from "@r2c/extension/content/github/TreeFindingsInjector";
 import RepoHeadsUpInjector from "@r2c/extension/content/headsup";
 import PreflightTwist from "@r2c/extension/content/PreflightTwist";
-import { ShareActionType, ShareSection } from "@r2c/extension/content/Share";
+import { ShareSection } from "@r2c/extension/content/Share";
 import { MainToaster } from "@r2c/extension/content/Toaster";
 import Twist, { TwistId } from "@r2c/extension/content/Twist";
 import Twists from "@r2c/extension/content/Twists";
@@ -208,14 +208,8 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
                       shortDesc={
                         "Hope you enjoy using the extension. Share our extension with your friends using the options below!"
                       }
-                      onEmailClick={l(
-                        "share-link-click-email",
-                        this.onShareActionClick("email")
-                      )}
-                      onLinkClick={l(
-                        "share-link-click-copy",
-                        this.onShareActionClick("link")
-                      )}
+                      onEmailClick={l("share-link-click-email")}
+                      onLinkClick={l("share-link-click-copy")}
                       user={user}
                       installationId={installationId}
                     />
@@ -257,7 +251,6 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
     mutations.forEach(mutation => {
       switch (mutation.type) {
         case "attributes":
-          console.log("mutation", mutation);
           if (mutation.target.nodeType === Node.ELEMENT_NODE) {
             const mutationElem = mutation.target as Element;
             if (
@@ -265,7 +258,6 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
               mutation.oldValue != null &&
               mutation.oldValue.indexOf("is-loading") >= 0
             ) {
-              console.log("Encountered navigable event");
               this.handleNavigationChange();
             }
           }
@@ -303,12 +295,6 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
     } else {
       this.setState({ twistTab: undefined, checklistItem: undefined });
     }
-  };
-
-  private onShareActionClick = (
-    buttonTitle: ShareActionType
-  ): React.MouseEventHandler<HTMLElement> => e => {
-    console.log("Logging share link action!");
   };
 
   private handleReportProject = (

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -138,6 +138,7 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
                       key={`BlobFindingsInjector ${this.state.currentUrl} ${
                         this.state.navigationNonce
                       }`}
+                      findingCommitHash={findingsData.commitHash}
                       findings={findingsData.findings}
                       repoSlug={this.repoSlug}
                     />
@@ -146,6 +147,7 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
                         this.state.navigationNonce
                       }`}
                       findings={findingsData.findings}
+                      commitHash={findingsData.commitHash}
                       repoSlug={this.repoSlug}
                     />
                   </>

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -37,6 +37,7 @@ import {
 } from "@r2c/extension/utils";
 import * as React from "react";
 import Fetch, { FetchUpdateOptions } from "react-fetch-component";
+import { PreflightChecklistItemType } from "./headsup/PreflightChecklist";
 import "./index.css";
 
 const DiscussionIcon: React.SFC = () => {
@@ -74,12 +75,13 @@ const ShareIcon: React.SFC = () => (
 );
 
 interface ContentHostState {
-  twistTab: string | undefined;
+  twistTab: TwistId | undefined;
   user: string | undefined;
   installationId: string;
   extensionState: ExtensionState | undefined;
   currentUrl: string;
   navigationNonce: number;
+  checklistItem: PreflightChecklistItemType | undefined;
 }
 
 export default class ContentHost extends React.Component<{}, ContentHostState> {
@@ -89,7 +91,8 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
     installationId: "not-generated",
     extensionState: undefined,
     currentUrl: window.location.href.replace(window.location.hash, ""),
-    navigationNonce: 0
+    navigationNonce: 0,
+    checklistItem: undefined
   };
 
   private repoSlug = extractSlugFromCurrentUrl();
@@ -117,6 +120,7 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
             key={`RepoHeadsUpInjector ${this.state.currentUrl} ${
               this.state.navigationNonce
             }`}
+            onChecklistItemClick={this.handleChecklistItemClick}
           />
           {this.repoSlug != null && (
             <Fetch<FindingsResponse> url={findingsUrlFromSlug(this.repoSlug)}>
@@ -167,7 +171,12 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
                       id="preflight"
                       title="Preflight"
                       icon={<PreflightIcon />}
-                      panel={<PreflightTwist repoSlug={this.repoSlug} />}
+                      panel={
+                        <PreflightTwist
+                          repoSlug={this.repoSlug}
+                          deepLink={this.state.checklistItem}
+                        />
+                      }
                     />
                   )}
                 <Twist
@@ -219,6 +228,12 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
       </>
     );
   }
+
+  private handleChecklistItemClick = (itemType: PreflightChecklistItemType) => (
+    e: React.MouseEvent<HTMLElement>
+  ) => {
+    this.setState({ twistTab: "preflight", checklistItem: itemType });
+  };
 
   private watchNavigationChange() {
     this.navigationMutationObserver = new MutationObserver(
@@ -284,9 +299,9 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
     e: React.MouseEvent<HTMLInputElement>
   ) => {
     if (this.state.twistTab !== twist) {
-      this.setState({ twistTab: twist });
+      this.setState({ twistTab: twist, checklistItem: undefined });
     } else {
-      this.setState({ twistTab: undefined });
+      this.setState({ twistTab: undefined, checklistItem: undefined });
     }
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,11 @@ if (window.browser == null && window.chrome != null) {
 
 export function getExtensionVersion(): string | undefined {
   if (browser != null && browser.runtime != null) {
-    return browser.runtime.getManifest().version;
+    const manifest = browser.runtime.getManifest();
+
+    if (manifest != null) {
+      return manifest.version;
+    }
   }
 
   return undefined;
@@ -129,7 +133,11 @@ export function isRepositoryPrivate() {
 }
 
 export function buildGithubProfilePicUrl(user: string): string {
-  return `https://github.com/${user}.png`;
+  return `${buildGithubProfileUrl(user)}.png`;
+}
+
+export function buildGithubProfileUrl(user: string): string {
+  return `https://github.com/${user}`;
 }
 
 export async function fetchStringFromStorage(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,7 +185,7 @@ export function buildFindingFileLink(
   commitHash: string | null,
   fileName: string,
   startLine: number | null,
-  endLine?: number
+  endLine?: number | null
 ): string {
   // TODO Retrieve default branch
   return `https://${repoSlug.domain}/${repoSlug.org}/${

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,9 @@ export interface ExtractedRepoSlug {
   repo: string;
   pathname: string;
   rest: string;
+  commitHash: string | undefined;
+  filePath: string | undefined;
+  seemsLikeCommitHash: boolean | undefined;
 }
 
 function parseSlugFromUrl(url: string): ExtractedRepoSlug {
@@ -84,7 +87,31 @@ function parseSlugFromUrl(url: string): ExtractedRepoSlug {
   const { hostname: domain, pathname } = parsed;
   const [org, repo, ...rest] = pathname.slice(1).split("/");
 
-  return { domain, org, repo, pathname, rest: rest.join("/") };
+  if (rest != null && rest.length > 0) {
+    const [commitHash, ...filePath] = rest.slice(1);
+
+    return {
+      domain,
+      org,
+      repo,
+      pathname,
+      rest: rest.join("/"),
+      commitHash,
+      filePath: filePath.join("/"),
+      seemsLikeCommitHash: commitHash.length === 40
+    };
+  } else {
+    return {
+      domain,
+      org,
+      repo,
+      pathname,
+      rest: rest.join("/"),
+      commitHash: undefined,
+      filePath: undefined,
+      seemsLikeCommitHash: undefined
+    };
+  }
 }
 
 export function extractSlugFromCurrentUrl(): ExtractedRepoSlug {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,6 +1137,10 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
+bail@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
+
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -1504,6 +1508,18 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
+
+character-entities@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -1637,6 +1653,10 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collapse-white-space@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2673,7 +2693,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -3537,6 +3557,17 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3547,7 +3578,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -3582,6 +3613,10 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3669,6 +3704,10 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
+
 is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
@@ -3716,7 +3755,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -3778,9 +3817,17 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4550,6 +4597,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -4564,6 +4615,12 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5188,6 +5245,17 @@ parse-asn1@^5.0.0:
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
+
+parse-entities@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -5888,6 +5956,17 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
+react-markdown@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.6.0.tgz#29f6aaab5270c8ef0a5e234093a873ec3e01722b"
+  dependencies:
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.6.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
+
 react-popper@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.2.tgz#0e72f338b7f15ab9f9ec884e36ae0dad78a3e301"
@@ -6145,6 +6224,26 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -6163,7 +6262,7 @@ repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -6172,6 +6271,10 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request-promise-core@1.1.1:
   version "1.1.1"
@@ -6706,6 +6809,10 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
+state-toggle@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7047,6 +7154,18 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
+
 ts-jest@22.0.1:
   version "22.0.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-22.0.1.tgz#48942936a466c2e76e259b02e2f1356f1839afc3"
@@ -7228,6 +7347,24 @@ uglifyjs-webpack-plugin@^1.1.8:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+unherit@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -7262,6 +7399,36 @@ unique-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
   dependencies:
     crypto-random-string "^1.0.0"
+
+unist-util-is@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+
+unist-util-visit-parents@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz#63fffc8929027bee04bfef7d2cce474f71cb6217"
+  dependencies:
+    unist-util-is "^2.1.2"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -7416,6 +7583,25 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
+
+vfile-message@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -7683,6 +7869,10 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
@@ -7691,7 +7881,7 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
There is a new manifest.

Changelog may be incomplete.

🚨 **For ease of review, consider reviewing commit-by-commit.** 🚨 The [GitHub PR plugin](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) for VS Code is quite handy!

### Added

- Code issues we discover are now displayed as a checklist item
- The Preflight manifest now shows findings, permissions, and vulnerabilities
- When Recon mode is enabled, we now show a message if we've found historical code issues on a source file you're looking at
- When the Preflight manifest is enabled, you can now click on a checklist item to jump to that section of the manifest

### Fixed

- Improved reliability of showing Preflight checklist and experimental Recon issue markers on the page
- Fixed some performance issues with the sidebar
- Fixed an issue where we'd display permissions in the manifest even if they weren't found in the project

# Feature presentation

_Featuring..._

![image](https://user-images.githubusercontent.com/1077648/45796993-1a593d00-bc58-11e8-86a0-a7568ab90598.png)

![image](https://user-images.githubusercontent.com/1077648/45796961-fc8bd800-bc57-11e8-9407-be26449a0436.png)

![image](https://user-images.githubusercontent.com/1077648/45796953-f695f700-bc57-11e8-9c81-64dfca9d504e.png)

![image](https://user-images.githubusercontent.com/1077648/45796982-0ca3b780-bc58-11e8-9692-30de7f8e9c38.png)

![image](https://user-images.githubusercontent.com/1077648/45796985-12999880-bc58-11e8-915c-49c81fe43f55.png)

![image](https://user-images.githubusercontent.com/1077648/45797004-28a75900-bc58-11e8-8bb1-e2177b24f7b9.png)

![image](https://user-images.githubusercontent.com/1077648/45797009-2fce6700-bc58-11e8-9f89-47eef7226f74.png)

