### PR TITLE
Misc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - We no longer show the Preflight sidebar on npmjs.com. We'll bring it back when we have more things to say about npm packages themselves.
 - Added instrumentation to inform us when people visit public repositories we don't have Preflight data for.
 
+### Fixed
+
+- Fixed an issue where we weren't showing the uninstall page properly (#64)
+
 ## [1.9.2] - 2018-09-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [1.9.3] - 2018-09-24
+
+### Changed
+
+- We no longer show the Preflight sidebar on npmjs.com. We'll bring it back when we have more things to say about npm packages themselves.
+- Added instrumentation to inform us when people visit public repositories we don't have Preflight data for.
+
 ## [1.9.2] - 2018-09-21
 
 ### Changed

--- a/public/background.js
+++ b/public/background.js
@@ -1,3 +1,16 @@
-(window.browser || window.chrome).runtime.setUninstallUrl(
-  "https://goo.gl/forms/B8ALNAcRHoLWHBVF2"
-);
+// tslint:disable
+
+const uninstallUrl = `https://goo.gl/forms/B8ALNAcRHoLWHBVF2`;
+const setUninstallUrl = new Promise((resolve, reject) => {
+  const shim = browser || chrome;
+  return shim.runtime.setUninstallURL(uninstallUrl, () => {
+    const lastError = shim.runtime.lastError;
+    if (lastError) {
+      reject(lastError);
+    } else {
+      resolve();
+    }
+  });
+});
+
+setUninstallUrl.catch(err => console.error("Error setting uninstall URL", err));

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "permissions": ["storage", "https://api.secarta.io/*", "activeTab"],
   "background": {
     "scripts": ["background.js"],
-    "persistent": true
+    "persistent": false
   },
   "applications": {
     "gecko": {

--- a/src/content/headsup/NonIdealHeadsup.tsx
+++ b/src/content/headsup/NonIdealHeadsup.tsx
@@ -22,6 +22,8 @@ export class UnsupportedHeadsUp extends React.PureComponent<
       return null;
     }
 
+    l("preflight-unsupported-repo-load");
+
     return (
       <div className="r2c-repo-headsup unsupported-headsup">
         <div className="unsupported-message">

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -32,6 +32,7 @@ import {
 import {
   extractSlugFromCurrentUrl,
   fetchOrCreateExtensionUniqueId,
+  isGitHubSlug,
   isRepositoryPrivate,
   userOrInstallationId
 } from "@r2c/extension/utils";
@@ -109,6 +110,10 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
     const { twistTab, user, installationId } = this.state;
 
     if (isRepositoryPrivate() || installationId === "not-generated") {
+      return null;
+    }
+
+    if (isGitHubSlug(this.repoSlug)) {
       return null;
     }
 

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -113,7 +113,7 @@ export default class ContentHost extends React.Component<{}, ContentHostState> {
       return null;
     }
 
-    if (isGitHubSlug(this.repoSlug)) {
+    if (!isGitHubSlug(this.repoSlug)) {
       return null;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,3 +262,7 @@ export function parseHash(hash: string): [number, number?] | null {
     return null;
   }
 }
+
+export function isGitHubSlug(repoSlug: ExtractedRepoSlug): boolean {
+  return repoSlug.domain.indexOf("github.com") < 0;
+}


### PR DESCRIPTION
Not necessarily a release by itself but it resolves a few things

## [1.9.3] - 2018-09-24

### Changed

- We no longer show the Preflight sidebar on npmjs.com. We'll bring it back when we have more things to say about npm packages themselves.
- Added instrumentation to inform us when people visit public repositories we don't have Preflight data for.

### Fixed

- Fixed an issue where we weren't showing the uninstall page properly (#64)
