### PR TITLE
Fix discussion icon in pop-out zero state

### DIFF
--- a/src/content/Discussion.tsx
+++ b/src/content/Discussion.tsx
@@ -5,6 +5,7 @@ import {
   getComments,
   submitComment
 } from "@r2c/extension/api/comments";
+import { SpeechBubblesIcon } from "@r2c/extension/icons";
 import UserProps from "@r2c/extension/shared/User";
 import { UserMetadataFooter } from "@r2c/extension/shared/UserMetadata";
 import { userOrInstallationId } from "@r2c/extension/utils";
@@ -93,11 +94,7 @@ class CommentsWell extends React.PureComponent<CommentsWellProps> {
       return (
         <div className="comments-well comments-well-empty">
           <NonIdealState
-            icon={
-              <svg width="24" height="24" fillRule="evenodd" clipRule="evenodd">
-                <path d="M24 20h-3v4l-5.333-4h-7.667v-4h2v2h6.333l2.667 2v-2h3v-8.001h-2v-2h4v12.001zm-15.667-6l-5.333 4v-4h-3v-14.001l18 .001v14h-9.667zm-6.333-2h3v2l2.667-2h8.333v-10l-14-.001v10.001z" />
-              </svg>
-            }
+            icon={<SpeechBubblesIcon />}
             description="Be the first to comment"
           />
         </div>


### PR DESCRIPTION
Missed a zero-state icon on earlier icon changes.