### PR TITLE
Don't show error state if we're still loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where missing packages would cause an error when showing used by (symptom of #50)
 - Fixed issues with error styling (#50)
 - Fixed incorrect display of checkmark when activity data couldn't be loaded (#89)
+- Fixed an issue where we were showing an error message and a loading box at the same time (#68)
 
 ### Removed
 

--- a/src/content/headsup/PreflightChecklist.tsx
+++ b/src/content/headsup/PreflightChecklist.tsx
@@ -383,10 +383,11 @@ export class PreflightChecklistFetch extends React.PureComponent<
                     packageResponse.loading ||
                     findingsResponse.loading;
 
-                  const error =
-                    repoResponse.error ||
-                    packageResponse.error ||
-                    findingsResponse.error;
+                  const error = !loading
+                    ? repoResponse.error ||
+                      packageResponse.error ||
+                      findingsResponse.error
+                    : undefined;
 
                   const data =
                     repoResponse.data != null &&


### PR DESCRIPTION
Resolves an issue where we were showing an error message and a loading box at the same time (fixes #68) 