### PR TITLE
Fix commit warning banner appearing even if no issue exists on current page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed incorrect display of checkmark when activity data couldn't be loaded (#89)
 - Fixed an issue where we were showing an error message and a loading box at the same time (#68)
 - Fixed an issue where the "Choose a package" search field wasn't actually hooked up 🤔 (#76)
+- Fixed an issue where we were showing the "Issues on other commit" warning banner even if there weren't any issues in the current file (#105)
 
 ### Removed
 

--- a/src/content/github/BlobFindingsInjector.tsx
+++ b/src/content/github/BlobFindingsInjector.tsx
@@ -20,7 +20,7 @@ const ApproximateFindingNotice: React.SFC<BlobFindingsHighlighterProps> = ({
   filePath
 }) => (
   <div className="approximate-finding-notice">
-    <header className="notice-title">Issues occurs in past commits</header>
+    <header className="notice-title">Issue occurs in another commit</header>
     <span className="notice-text">Location may be approximate</span>
     <CommitChooser
       repoSlug={repoSlug}

--- a/src/content/headsup/CommitWarningHeadsUp.tsx
+++ b/src/content/headsup/CommitWarningHeadsUp.tsx
@@ -138,6 +138,7 @@ export default class CommitWarningHeadsUp extends React.PureComponent<
   private renderInjected() {
     const { repoSlug, filePath, findings, debug } = this.props;
     const commitHashes = new Set(findings
+      .filter(finding => finding.fileName === filePath)
       .map(finding => finding.commitHash)
       .filter(f => f) as string[]);
 

--- a/src/content/headsup/CommitWarningHeadsUp.tsx
+++ b/src/content/headsup/CommitWarningHeadsUp.tsx
@@ -62,7 +62,7 @@ export class CommitChooser extends React.PureComponent<CommitChooserProps> {
           onClick={l("commit-warning-action-click")}
           className="past-commit-action-button"
         >
-          Go to past commit
+          Go to exact commit
         </AnchorButton>
       );
     } else if (commitGroups.length > 1) {
@@ -83,7 +83,7 @@ export class CommitChooser extends React.PureComponent<CommitChooserProps> {
           <Button
             className="commit-hash-select-dropdown-button"
             rightIcon={IconNames.CARET_DOWN}
-            text="Go to past commit..."
+            text="Go to exact commit..."
             intent={Intent.SUCCESS}
           />
         </CommitSelect>
@@ -181,8 +181,8 @@ export default class CommitWarningHeadsUp extends React.PureComponent<
       <div className="r2c-repo-headsup commit-warning-headsup">
         <div className="headsup-inline-message">
           <span className="headsup-different-commit">
-            We're showing issues that we found in past commits, so markers may
-            not be exact. Go to past commits for exact issue locations.
+            We're showing issues that we found in other commits, so markers may
+            not be exact.
           </span>
           <CommitChooser
             filePath={filePath}


### PR DESCRIPTION
Caused because we didn't actually filter the list of findings by their file path before deciding to show the commit warning banner. This filtering already takes place when placing the inline markers for each file. Not sure why we didn't see this earlier...

Fixes #105 