### PR TITLE
Explorable permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed where "Choose a package" search field wasn't actually hooked up 🤔 (#76)
 - Fixed accidentally showing the "Issues on other commit" warning banner even if there weren't any issues in the current file (#105)
 - Fixed the package select box moving about on small screens (#73)
+- Fixed parsing of GitHub URLs so a trailing slash doesn't break things
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added `esc` as hotkey to close Preflight side panel when it's open
 - Added a way to provide feedback and chat with us via Intercom. Click on the extension icon in the browser toolbar and click "Feedback".
+- You can now explore locations in the project where we found permissions
 
 ### Changed
 

--- a/src/api/permissions.ts
+++ b/src/api/permissions.ts
@@ -1,4 +1,5 @@
 import { extractSlugFromCurrentUrl } from "@r2c/extension/utils";
+import { FindingEntry } from "./findings";
 
 export function permissionsUrl() {
   const { domain, org, repo } = extractSlugFromCurrentUrl();
@@ -10,12 +11,7 @@ export interface PermissionEntry {
   name: string;
   displayName: string;
   found: boolean;
-  locations: PermissionLocation[];
-}
-
-export interface PermissionLocation {
-  file_name: string;
-  start_line: number;
+  locations: FindingEntry[];
 }
 
 export interface PermissionsResponse {

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -21,7 +21,7 @@ import {
   vulnsUrl
 } from "@r2c/extension/api/vulns";
 import FindingsGroupedList from "@r2c/extension/content/FindingsGroupedList";
-import { buildFindingFileLink, ExtractedRepoSlug } from "@r2c/extension/utils";
+import { ExtractedRepoSlug } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import { sumBy } from "lodash";
 import * as React from "react";
@@ -308,23 +308,11 @@ export default class PreflightTwist extends React.PureComponent<
                                   <span className="permission-entry-name">
                                     {data.permissions[key].displayName}
                                   </span>
-                                  {data.permissions[key].locations.map(
-                                    location =>
-                                      location.file_name != null &&
-                                      location.start_line != null && (
-                                        <a
-                                          href={buildFindingFileLink(
-                                            repoSlug,
-                                            data.commitHash,
-                                            location.file_name,
-                                            location.start_line
-                                          )}
-                                        >
-                                          {location.file_name}:
-                                          {location.start_line}
-                                        </a>
-                                      )
-                                  )}
+                                  <FindingsGroupedList
+                                    commitHash={data.commitHash}
+                                    findings={data.permissions[key].locations}
+                                    repoSlug={repoSlug}
+                                  />
                                 </div>
                               )
                           )}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,7 +109,8 @@ function parseSlugFromUrl(url: string): ExtractedRepoSlug {
       rest: rest.join("/"),
       commitHash,
       filePath: filePath.join("/"),
-      seemsLikeCommitHash: commitHash.length === 40,
+      seemsLikeCommitHash:
+        commitHash != null ? commitHash.length === 40 : undefined,
       startLineHash: startLine,
       endLineHash: endLine
     };


### PR DESCRIPTION
- You can now explore locations in the project where we found permissions 
- Fixed parsing of GitHub URLs so a trailing slash doesn't break things 

Resolves #74