### PR TITLE
Fix an issue where the tree findings popup wasn't linking issues properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- When you click on the issues badge next to a file or folder, you can now go directly to the individual files and issues by clicking on them.
+- When you click on the issues badge next to a file or folder, you can now go directly to the individual files and issues by clicking on them. (#102)
 
 ## [1.10.1] - 2018-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- When you click on the issues badge next to a file or folder, you can now go directly to the individual files and issues by clicking on them.
+
 ## [1.10.1] - 2018-10-02
 
 ### Fixed

--- a/src/content/github/TreeFindingsInjector.tsx
+++ b/src/content/github/TreeFindingsInjector.tsx
@@ -21,6 +21,7 @@ interface TreeFindingsHighlighterProps extends TreeFindingsInjectorProps {
 
 interface TreeFindingHighlightProps {
   findings: FindingEntry[];
+  repoSlug: ExtractedRepoSlug;
   commitHash: string;
   path: string;
 }
@@ -29,7 +30,7 @@ class TreeFindingHighlight extends React.PureComponent<
   TreeFindingHighlightProps
 > {
   public render() {
-    const { findings, commitHash, path } = this.props;
+    const { findings, commitHash, path, repoSlug } = this.props;
 
     return (
       <DOMInjector
@@ -44,6 +45,7 @@ class TreeFindingHighlight extends React.PureComponent<
             <FindingsGroupedList
               findings={findings}
               commitHash={commitHash}
+              repoSlug={repoSlug}
               className="r2c-tree-findings-grouped-list"
             />
           }
@@ -69,7 +71,7 @@ class TreeFindingsHighlighter extends React.PureComponent<
   TreeFindingsHighlighterProps
 > {
   public render() {
-    const { currentPath, findings, commitHash } = this.props;
+    const { currentPath, findings, commitHash, repoSlug } = this.props;
 
     const filtered = findings.filter(finding =>
       finding.fileName.startsWith(currentPath)
@@ -92,6 +94,7 @@ class TreeFindingsHighlighter extends React.PureComponent<
       <>
         {[...immediatePathChildren.values()].map(directoryEntry => (
           <TreeFindingHighlight
+            repoSlug={repoSlug}
             key={directoryEntry}
             commitHash={commitHash}
             findings={filtered.filter(finding =>


### PR DESCRIPTION
### Changed

- When you click on the issues badge next to a file or folder, you can now go directly to the individual files and issues by clicking on them.

Fixes https://github.com/returntocorp/secarta-extension/issues/102