### PR TITLE
Fix Chrome missing uninstall hook due to unsupported `window.browser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed the email button in the Feedback tab not navigating properly
+- Fixed a missing uninstall hook in Chrome since it doesn't support `window.browser` (#64)
 
 ## [1.10.0] - 2018-10-01
 

--- a/public/background.js
+++ b/public/background.js
@@ -2,7 +2,7 @@
 
 const uninstallUrl = `https://goo.gl/forms/B8ALNAcRHoLWHBVF2`;
 const setUninstallUrl = new Promise((resolve, reject) => {
-  const shim = browser || chrome;
+  const shim = window.browser || window.chrome;
   return shim.runtime.setUninstallURL(uninstallUrl, () => {
     const lastError = shim.runtime.lastError;
     if (lastError) {


### PR DESCRIPTION
Resolves #64