### PR TITLE
Scripts endpoint and cleanup state flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,10 @@
     "tslint-microsoft-contrib": "^5.2.0",
     "typescript": "^3.0.1",
     "write-file-webpack-plugin": "^4.3.2"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^@r2c/extension/(.*)$": "<rootDir>/src/$1"
+    }
   }
 }

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -1,13 +1,13 @@
 import { extractSlugFromCurrentUrl } from "@r2c/extension/utils";
 
-export function packageUrl() {
+export function packageUrl(version: string = "v2") {
   const { domain, org, repo } = extractSlugFromCurrentUrl();
 
-  return `https://api.secarta.io/v2/package/${domain}/${org}/${repo}`;
+  return `https://api.secarta.io/${version}/package/${domain}/${org}/${repo}`;
 }
 
 export function relatedPackagesUrl() {
-  return `${packageUrl()}/related`;
+  return `${packageUrl("v1")}/related`;
 }
 
 export interface PackageEntry {

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -18,18 +18,9 @@ export interface PackageEntry {
   rank_description: string;
 }
 
-export interface ScriptEntry {
-  script: string;
-
-  // Disabling TSlint because the API returns a property called `type`
-  // tslint:disable-next-line:no-reserved-keywords
-  type: string;
-}
-
 export interface PackageResponse {
   gitUrl: string;
   packages: PackageEntry[];
-  npmScripts: ScriptEntry[];
 }
 
 export interface RelatedPackageEntry {

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -3,7 +3,7 @@ import { extractSlugFromCurrentUrl } from "@r2c/extension/utils";
 export function packageUrl() {
   const { domain, org, repo } = extractSlugFromCurrentUrl();
 
-  return `https://api.secarta.io/v1/package/${domain}/${org}/${repo}`;
+  return `https://api.secarta.io/v2/package/${domain}/${org}/${repo}`;
 }
 
 export function relatedPackagesUrl() {

--- a/src/api/scripts.ts
+++ b/src/api/scripts.ts
@@ -1,0 +1,20 @@
+import { extractSlugFromCurrentUrl } from "@r2c/extension/utils";
+
+export function scriptsUrl() {
+  const { domain, org, repo } = extractSlugFromCurrentUrl();
+
+  return `https://api.secarta.io/v1/scripts/${domain}/${org}/${repo}`;
+}
+
+export interface ScriptsResponse {
+  gitUrl: string;
+  scripts: ScriptEntry[] | null;
+}
+
+export interface ScriptEntry {
+  script: string;
+
+  // Disabling TSlint because the API returns a property called `type`
+  // tslint:disable-next-line:no-reserved-keywords
+  type: string;
+}

--- a/src/content/ActionButton.tsx
+++ b/src/content/ActionButton.tsx
@@ -1,5 +1,4 @@
 import { Intent, Position, Tooltip } from "@blueprintjs/core";
-import { intentClass } from "@blueprintjs/core/lib/esm/common/classes";
 import { l } from "@r2c/extension/analytics";
 import { TwistId } from "@r2c/extension/content/Twist";
 import * as classnames from "classnames";
@@ -49,7 +48,7 @@ export default class ActionButton extends React.PureComponent<
         className={classnames(
           "r2c-action-button",
           `${id}-action-button`,
-          intentClass(intent),
+          intent,
           {
             "action-button-selected": selected
           }

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -6,14 +6,14 @@ import {
   findingsUrlFromSlug
 } from "@r2c/extension/api/findings";
 import {
-  PackageResponse,
-  packageUrl,
-  ScriptEntry
-} from "@r2c/extension/api/package";
-import {
   PermissionsResponse,
   permissionsUrl
 } from "@r2c/extension/api/permissions";
+import {
+  ScriptEntry,
+  ScriptsResponse,
+  scriptsUrl
+} from "@r2c/extension/api/scripts";
 import {
   VulnerabilityEntry,
   VulnsResponse,
@@ -410,30 +410,37 @@ export default class PreflightTwist extends React.PureComponent<
                     </PreflightSection>
                   )}
                 </ApiFetch>
-                <ApiFetch<PackageResponse> url={packageUrl()}>
+                <ApiFetch<ScriptsResponse> url={scriptsUrl()}>
                   {({ data, loading }) => (
                     <PreflightSection
                       check="scripts"
                       title="Install hooks"
                       description="Hooks can run before or after installing this package, and their presence can indicate a security issue."
                       startOpen={
-                        (data != null && data.npmScripts.length > 0) ||
+                        (data != null &&
+                          data.scripts != null &&
+                          data.scripts.length > 0) ||
                         deepLink === "scripts"
                       }
-                      count={data != null ? data.npmScripts.length : undefined}
+                      count={
+                        data != null && data.scripts != null
+                          ? data.scripts.length
+                          : undefined
+                      }
                       loading={loading}
                       domRef={this.twistRefs.scripts}
                     >
-                      {data && (
-                        <div className="install-hooks">
-                          {data.npmScripts.map((script, i) => (
-                            <PreflightInstallHook
-                              script={script}
-                              key={`${script.type}_${i}`}
-                            />
-                          ))}
-                        </div>
-                      )}
+                      {data &&
+                        data.scripts != null && (
+                          <div className="install-hooks">
+                            {data.scripts.map((script, i) => (
+                              <PreflightInstallHook
+                                script={script}
+                                key={`${script.type}_${i}`}
+                              />
+                            ))}
+                          </div>
+                        )}
                     </PreflightSection>
                   )}
                 </ApiFetch>

--- a/src/content/headsup/NonIdealHeadsup.tsx
+++ b/src/content/headsup/NonIdealHeadsup.tsx
@@ -1,6 +1,8 @@
 import { Button, Icon, Intent, Spinner } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { l } from "@r2c/extension/analytics";
+import { PreflightChecklistErrors } from "@r2c/extension/content/headsup/PreflightFetch";
+import { PreflightProjectState } from "@r2c/extension/content/headsup/PreflightProjectState";
 import { MainToaster } from "@r2c/extension/content/Toaster";
 import * as classnames from "classnames";
 import * as React from "react";
@@ -74,7 +76,8 @@ export class UnsupportedHeadsUp extends React.PureComponent<
 }
 
 interface ErrorHeadsUpProps {
-  error: React.ErrorInfo | Error;
+  projectState: PreflightProjectState;
+  error: PreflightChecklistErrors | Error | React.ErrorInfo | string;
 }
 
 interface ErrorHeadsUpState {
@@ -127,6 +130,7 @@ export class ErrorHeadsUp extends React.PureComponent<
         </div>
         {this.state.showDetails && (
           <div className="error-details">
+            <pre className="error-code">{this.props.projectState}</pre>
             <pre className="error-raw">{JSON.stringify(this.props.error)}</pre>
           </div>
         )}

--- a/src/content/headsup/NormalHeadsup.tsx
+++ b/src/content/headsup/NormalHeadsup.tsx
@@ -1,10 +1,11 @@
 import { PackageEntry } from "@r2c/extension/api/package";
 import { HeadsUpProps } from "@r2c/extension/content/headsup";
 import PackageCopyBox from "@r2c/extension/content/headsup/PackageCopyBox";
+import { PreflightChecklist } from "@r2c/extension/content/headsup/PreflightChecklist";
 import {
-  PreflightChecklist,
-  PreflightChecklistFetchData
-} from "@r2c/extension/content/headsup/PreflightChecklist";
+  PreflightChecklistFetchData,
+  PreflightChecklistLoading
+} from "@r2c/extension/content/headsup/PreflightFetch";
 import RelatedPackages from "@r2c/extension/content/headsup/RelatedPackages";
 import UsedBy from "@r2c/extension/content/headsup/UsedBy";
 import LastUpdatedBadge from "@r2c/extension/content/LastUpdatedBadge";
@@ -14,6 +15,7 @@ import "./index.css";
 
 interface NormalHeadsUpProps extends HeadsUpProps {
   data: PreflightChecklistFetchData;
+  loading: PreflightChecklistLoading;
 }
 
 interface NormalHeadsUpState {
@@ -29,7 +31,7 @@ export default class NormalHeadsUp extends React.PureComponent<
   };
 
   public render() {
-    const { data } = this.props;
+    const { data, loading } = this.props;
     const { selectedPackage } = this.state;
 
     return (
@@ -39,18 +41,21 @@ export default class NormalHeadsUp extends React.PureComponent<
             <span className="preflight-logo">preflight</span>
           </div>
           <div className="checklist-right">
-            <LastUpdatedBadge
-              commitHash={data.repo.commitHash}
-              lastUpdatedDate={new Date(data.repo.analyzedAt)}
-              repoSlug={this.props.repoSlug}
-            />
+            {data.repo != null && (
+              <LastUpdatedBadge
+                commitHash={data.repo.commitHash}
+                lastUpdatedDate={new Date(data.repo.analyzedAt)}
+                repoSlug={this.props.repoSlug}
+              />
+            )}
             <R2CLogo />
           </div>
         </header>
         <div className="repo-headsup-body">
           <div className="repo-headsup-checklist repo-headsup-column">
             <PreflightChecklist
-              {...data}
+              data={data}
+              loading={loading}
               onChecklistItemClick={this.props.onChecklistItemClick}
             />
           </div>

--- a/src/content/headsup/NormalHeadsup.tsx
+++ b/src/content/headsup/NormalHeadsup.tsx
@@ -62,7 +62,11 @@ export default class NormalHeadsUp extends React.PureComponent<
           {data.pkg &&
             selectedPackage && (
               <div className="repo-headsup-supplemental repo-headsup-column">
-                <UsedBy pkg={data.pkg} selectedPackage={selectedPackage} />
+                <UsedBy
+                  pkg={data.pkg}
+                  selectedPackage={selectedPackage}
+                  loading={loading.pkg}
+                />
                 <RelatedPackages selectedPackage={selectedPackage} />
               </div>
             )}
@@ -70,6 +74,7 @@ export default class NormalHeadsUp extends React.PureComponent<
             <PackageCopyBox
               packages={data.pkg}
               onSelectPackage={this.handlePackageSelect}
+              loading={loading.pkg}
             />
           </div>
         </div>

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -239,6 +239,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
 }
 
 interface WrappedPackageCopyBoxProps {
+  loading: boolean | null;
   packages: PackageResponse | undefined;
   selectedPackage?: PackageEntry;
   packageManager?: PackageManagerChoice;
@@ -298,11 +299,17 @@ export default class WrappedPackageCopyBox extends React.Component<
   }
 
   public render() {
-    const { packages: data } = this.props;
+    const { packages: data, loading } = this.props;
 
     const { selectedPackage, packageManager } = this.state;
 
-    if (data == null || data.packages.length === 0) {
+    if (loading) {
+      return (
+        <section className={classnames("package-copy-box", Classes.SKELETON)}>
+          <NonIdealState icon="box" description="Loading..." />
+        </section>
+      );
+    } else if (data == null || data.packages.length === 0) {
       return (
         <section className="package-copy-box">
           <NonIdealState icon="box" description="Not published to npm" />

--- a/src/content/headsup/PreflightChecklist.tsx
+++ b/src/content/headsup/PreflightChecklist.tsx
@@ -1,27 +1,18 @@
 import { Button, Classes, Icon, IIconProps, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { ApiFetch } from "@r2c/extension/api/fetch";
-import {
-  FindingEntry,
-  FindingsResponse,
-  findingsUrl
-} from "@r2c/extension/api/findings";
-import {
-  PackageEntry,
-  PackageResponse,
-  packageUrl
-} from "@r2c/extension/api/package";
+import { FindingEntry } from "@r2c/extension/api/findings";
+import { PackageEntry } from "@r2c/extension/api/package";
 import {
   PermissionsResponse,
   permissionsUrl
 } from "@r2c/extension/api/permissions";
-import { RepoResponse, repoUrl } from "@r2c/extension/api/repo";
-import {
-  ScriptEntry,
-  ScriptsResponse,
-  scriptsUrl
-} from "@r2c/extension/api/scripts";
+import { ScriptEntry } from "@r2c/extension/api/scripts";
 import { VulnsResponse, vulnsUrl } from "@r2c/extension/api/vulns";
+import {
+  PreflightChecklistFetchData,
+  PreflightChecklistLoading
+} from "@r2c/extension/content/headsup/PreflightFetch";
 import * as classnames from "classnames";
 import { sumBy } from "lodash";
 import * as React from "react";
@@ -55,13 +46,16 @@ function getIconPropsForState(state: ChecklistItemState): IIconProps {
 }
 
 interface PreflightChecklistInteractionProps {
-  onChecklistItemClick(
-    itemType: PreflightChecklistItemType
-  ): React.MouseEventHandler<HTMLElement>;
+  loading?: boolean | null;
+  onChecklistItemClick: PreflightChecklistItemClickHandler;
 }
 
+type PreflightChecklistItemClickHandler = (
+  itemType: PreflightChecklistItemType
+) => React.MouseEventHandler<HTMLElement>;
+
 interface PreflightChecklistItemProps {
-  loading?: boolean;
+  loading?: boolean | null;
   itemType: PreflightChecklistItemType;
   iconState: ChecklistItemState;
   onChecklistItemClick(
@@ -227,6 +221,7 @@ const PreflightScriptsItem: React.SFC<PreflightScriptsItemProps> = props => {
       iconState={itemState}
       itemType="scripts"
       onChecklistItemClick={props.onChecklistItemClick}
+      loading={props.loading}
     >
       {props.scripts != null
         ? props.scripts.length > 0
@@ -264,6 +259,7 @@ const PreflightRankItem: React.SFC<PreflightRankItemProps> = props => {
       iconState={itemState}
       itemType="rank"
       onChecklistItemClick={props.onChecklistItemClick}
+      loading={props.loading}
     >
       {props.pkg !== null && props.pkg && props.pkg.rank_description
         ? description
@@ -279,7 +275,8 @@ interface PreflightFindingsItemProps
 
 const PreflightFindingsItem: React.SFC<PreflightFindingsItemProps> = ({
   findings,
-  onChecklistItemClick
+  onChecklistItemClick,
+  loading
 }) => {
   if (findings == null) {
     return (
@@ -307,6 +304,7 @@ const PreflightFindingsItem: React.SFC<PreflightFindingsItemProps> = ({
         iconState={"warn"}
         itemType="findings"
         onChecklistItemClick={onChecklistItemClick}
+        loading={loading}
       >
         {findings.length} {findings.length === 1 ? "issue" : "issues"} in code
       </PreflightChecklistItem>
@@ -314,99 +312,21 @@ const PreflightFindingsItem: React.SFC<PreflightFindingsItemProps> = ({
   }
 };
 
-interface PreflightChecklistFetchProps {
-  children(response: PreflightChecklistFetchResponse): React.ReactNode;
+interface PreflightChecklistProps {
+  data: PreflightChecklistFetchData;
+  loading: PreflightChecklistLoading;
+  onChecklistItemClick: PreflightChecklistItemClickHandler;
 }
-
-export interface PreflightChecklistFetchData {
-  repo: RepoResponse;
-  pkg: PackageResponse | undefined;
-  scripts: ScriptsResponse | undefined;
-  findings: FindingsResponse | undefined;
-}
-
-type PreflightChecklistFetchDataResponse = {
-  [K in keyof PreflightChecklistFetchData]: Response
-};
-
-interface PreflightChecklistFetchResponse {
-  loading: boolean | null;
-  error: Error | undefined;
-  data: PreflightChecklistFetchData | undefined;
-  response: PreflightChecklistFetchDataResponse | undefined;
-}
-
-export class PreflightChecklistFetch extends React.PureComponent<
-  PreflightChecklistFetchProps
-> {
-  public render() {
-    return (
-      <ApiFetch<RepoResponse> url={repoUrl()}>
-        {repoResponse => (
-          <ApiFetch<PackageResponse> url={packageUrl()}>
-            {packageResponse => (
-              <ApiFetch<FindingsResponse> url={findingsUrl()}>
-                {findingsResponse => (
-                  <ApiFetch<ScriptsResponse> url={scriptsUrl()}>
-                    {scriptsResponse => {
-                      const loading =
-                        repoResponse.loading ||
-                        packageResponse.loading ||
-                        findingsResponse.loading ||
-                        scriptsResponse.loading;
-
-                      const error = !loading ? repoResponse.error : undefined;
-
-                      const data =
-                        !loading && repoResponse.data != null
-                          ? {
-                              repo: repoResponse.data,
-                              pkg: packageResponse.data,
-                              findings: findingsResponse.data,
-                              scripts: scriptsResponse.data
-                            }
-                          : undefined;
-
-                      const response =
-                        repoResponse.response != null &&
-                        packageResponse.response != null &&
-                        findingsResponse.response != null
-                          ? {
-                              repo: repoResponse.response,
-                              pkg: packageResponse.response,
-                              findings: findingsResponse.response,
-                              scripts: scriptsResponse.response
-                            }
-                          : undefined;
-
-                      const fetchResponse: PreflightChecklistFetchResponse = {
-                        loading,
-                        error,
-                        data,
-                        response
-                      };
-
-                      return this.props.children(fetchResponse);
-                    }}
-                  </ApiFetch>
-                )}
-              </ApiFetch>
-            )}
-          </ApiFetch>
-        )}
-      </ApiFetch>
-    );
-  }
-}
-
-type PreflightChecklistProps = PreflightChecklistFetchData &
-  PreflightChecklistInteractionProps;
 
 export class PreflightChecklist extends React.PureComponent<
   PreflightChecklistProps
 > {
   public render() {
-    const { pkg, findings, scripts, onChecklistItemClick: o } = this.props;
+    const {
+      data: { pkg, findings, scripts },
+      loading,
+      onChecklistItemClick: o
+    } = this.props;
 
     return (
       <section className="preflight-checklist-container">
@@ -424,6 +344,7 @@ export class PreflightChecklist extends React.PureComponent<
                     : undefined
                 }
                 onChecklistItemClick={o}
+                loading={loading.scripts}
               />
               <PreflightRankItem
                 onChecklistItemClick={o}
@@ -439,6 +360,7 @@ export class PreflightChecklist extends React.PureComponent<
               <PreflightFindingsItem
                 onChecklistItemClick={o}
                 findings={findings ? findings.findings : undefined}
+                loading={loading.findings}
               />
             </ul>
           )}

--- a/src/content/headsup/PreflightFetch.tsx
+++ b/src/content/headsup/PreflightFetch.tsx
@@ -1,0 +1,147 @@
+import { ApiFetch } from "@r2c/extension/api/fetch";
+import { FindingsResponse, findingsUrl } from "@r2c/extension/api/findings";
+import { PackageResponse, packageUrl } from "@r2c/extension/api/package";
+import { RepoResponse, repoUrl } from "@r2c/extension/api/repo";
+import { ScriptsResponse, scriptsUrl } from "@r2c/extension/api/scripts";
+import * as React from "react";
+
+interface PreflightChecklistFetchProps {
+  children(response: PreflightChecklistFetchResponse): React.ReactNode;
+}
+
+type PartialCoverage = { every: boolean | null; some: boolean | null };
+
+interface PreflightChecklistFetchDataContents {
+  repo: RepoResponse | undefined;
+  pkg: PackageResponse | undefined;
+  scripts: ScriptsResponse | undefined;
+  findings: FindingsResponse | undefined;
+}
+
+export type PreflightChecklistFetchData = PreflightChecklistFetchDataContents &
+  PartialCoverage;
+
+export type PreflightChecklistFetchDataResponse = {
+  [K in keyof PreflightChecklistFetchDataContents]: Response
+};
+
+export type PreflightChecklistLoading = {
+  [K in keyof PreflightChecklistFetchDataContents]: boolean | null
+} &
+  PartialCoverage;
+
+export type PreflightChecklistErrors = {
+  [K in keyof PreflightChecklistFetchDataContents]: Error | undefined
+} &
+  PartialCoverage;
+
+export interface PreflightChecklistFetchResponse {
+  loading: PreflightChecklistLoading;
+  error: PreflightChecklistErrors | undefined;
+  data: PreflightChecklistFetchData | undefined;
+  response: PreflightChecklistFetchDataResponse | undefined;
+}
+
+export default class PreflightFetch extends React.PureComponent<
+  PreflightChecklistFetchProps
+> {
+  public render() {
+    return (
+      <ApiFetch<RepoResponse> url={repoUrl()}>
+        {repoResponse => (
+          <ApiFetch<PackageResponse> url={packageUrl()}>
+            {packageResponse => (
+              <ApiFetch<FindingsResponse> url={findingsUrl()}>
+                {findingsResponse => (
+                  <ApiFetch<ScriptsResponse> url={scriptsUrl()}>
+                    {scriptsResponse => {
+                      // TODO yeah I know all of these ternaries are gross
+                      // TBD spending some time figuring out how to build a typesafe
+                      // way to reusably compute `every` and `some` as booleans
+                      // tslint:disable-next-line:cyclomatic-complexity
+                      const loading: PreflightChecklistLoading = {
+                        repo: repoResponse.loading,
+                        pkg: packageResponse.loading,
+                        findings: findingsResponse.loading,
+                        scripts: scriptsResponse.loading,
+                        every:
+                          repoResponse.loading &&
+                          packageResponse.loading &&
+                          findingsResponse.loading &&
+                          scriptsResponse.loading,
+                        some:
+                          repoResponse.loading ||
+                          packageResponse.loading ||
+                          findingsResponse.loading ||
+                          scriptsResponse.loading
+                      };
+
+                      const error = !loading.every
+                        ? {
+                            repo: repoResponse.error,
+                            pkg: packageResponse.error,
+                            findings: findingsResponse.error,
+                            scripts: scriptsResponse.error,
+                            some:
+                              repoResponse.error != null ||
+                              packageResponse.error != null ||
+                              findingsResponse.error != null ||
+                              scriptsResponse.error != null,
+                            every:
+                              repoResponse.error != null &&
+                              packageResponse.error != null &&
+                              findingsResponse != null &&
+                              scriptsResponse.error != null
+                          }
+                        : undefined;
+
+                      const data = !loading.every
+                        ? {
+                            repo: repoResponse.data,
+                            pkg: packageResponse.data,
+                            findings: findingsResponse.data,
+                            scripts: scriptsResponse.data,
+                            every:
+                              repoResponse.data != null &&
+                              packageResponse.data != null &&
+                              findingsResponse.data != null &&
+                              scriptsResponse.data != null,
+                            some:
+                              repoResponse.data != null ||
+                              packageResponse.data != null ||
+                              findingsResponse.data != null ||
+                              scriptsResponse.data != null
+                          }
+                        : undefined;
+
+                      const response =
+                        repoResponse.response != null &&
+                        packageResponse.response != null &&
+                        findingsResponse.response != null
+                          ? {
+                              repo: repoResponse.response,
+                              pkg: packageResponse.response,
+                              findings: findingsResponse.response,
+                              scripts: scriptsResponse.response
+                            }
+                          : undefined;
+
+                      const fetchResponse: PreflightChecklistFetchResponse = {
+                        loading,
+                        error,
+                        data,
+                        response
+                      };
+
+                      return this.props.children(fetchResponse);
+                    }}
+                  </ApiFetch>
+                )}
+              </ApiFetch>
+            )}
+          </ApiFetch>
+        )}
+      </ApiFetch>
+    );
+  }
+}

--- a/src/content/headsup/PreflightProjectState.test.ts
+++ b/src/content/headsup/PreflightProjectState.test.ts
@@ -1,12 +1,18 @@
 import { flowProjectState } from "@r2c/extension/content/headsup";
 import {
   PreflightChecklistErrors,
+  PreflightChecklistFetchData,
+  PreflightChecklistFetchDataResponse,
   PreflightChecklistLoading
 } from "@r2c/extension/content/headsup/PreflightFetch";
 import {
+  COMPLETE,
+  ERROR_API,
+  ERROR_MISSING_DATA,
   ERROR_UNKNOWN,
   LOADING_ALL,
-  LOADING_SOME
+  LOADING_SOME,
+  PARTIAL
 } from "@r2c/extension/content/headsup/PreflightProjectState";
 
 describe("Project state", () => {
@@ -78,6 +84,110 @@ describe("Project state", () => {
       repo: undefined,
       scripts: new Error("some error")
     };
+    expect(flowProjectState({ ...blank, error })).toBe(ERROR_UNKNOWN);
+  });
+
+  it("shows partial data when there's data and some responses have errored out", () => {
+    const error: PreflightChecklistErrors = {
+      every: false,
+      some: true,
+      findings: undefined,
+      pkg: undefined,
+      repo: undefined,
+      scripts: new Error("some error")
+    };
+    const data: PreflightChecklistFetchData = {
+      some: true,
+      every: false,
+      findings: undefined,
+      pkg: undefined,
+      repo: undefined,
+      scripts: { gitUrl: "foo", scripts: [] }
+    };
+    expect(flowProjectState({ ...blank, data, error })).toBe(PARTIAL);
+  });
+
+  it("shows complete data when there's all data, but some responses have errored out", () => {
+    const error: PreflightChecklistErrors = {
+      every: false,
+      some: true,
+      findings: undefined,
+      pkg: undefined,
+      repo: undefined,
+      scripts: new Error("some error")
+    };
+    const data: PreflightChecklistFetchData = {
+      some: true,
+      every: true,
+      findings: { gitUrl: "foo", findings: [], commitHash: "bar" },
+      pkg: { gitUrl: "foo", packages: [] },
+      repo: {
+        gitUrl: "foo",
+        commitHash: "bar",
+        activity: {
+          archived: false,
+          isActive: false,
+          latestCommitDate: "date"
+        },
+        analyzedAt: "analyzed"
+      },
+      scripts: { gitUrl: "foo", scripts: [] }
+    };
+    expect(flowProjectState({ ...blank, data, error })).toBe(COMPLETE);
+  });
+
+  it("shows missing data if all responses are 404 and all errors are triggered", () => {
+    const error: PreflightChecklistErrors = {
+      every: true,
+      some: true,
+      findings: new Error("some error"),
+      pkg: new Error("some error"),
+      repo: new Error("some error"),
+      scripts: new Error("some error")
+    };
+
+    const response: PreflightChecklistFetchDataResponse = {
+      findings: new Response(null, { status: 404 }),
+      pkg: new Response(null, { status: 404 }),
+      repo: new Response(null, { status: 404 }),
+      scripts: new Response(null, { status: 404 })
+    };
+
+    expect(flowProjectState({ ...blank, response, error })).toBe(
+      ERROR_MISSING_DATA
+    );
+  });
+
+  it("shows API issues if not responses are 404 and all errors are triggered", () => {
+    const error: PreflightChecklistErrors = {
+      every: true,
+      some: true,
+      findings: new Error("some error"),
+      pkg: new Error("some error"),
+      repo: new Error("some error"),
+      scripts: new Error("some error")
+    };
+
+    const response: PreflightChecklistFetchDataResponse = {
+      findings: new Response(null, { status: 404 }),
+      pkg: new Response(null, { status: 404 }),
+      repo: new Response(null, { status: 404 }),
+      scripts: new Response(null, { status: 500 })
+    };
+
+    expect(flowProjectState({ ...blank, response, error })).toBe(ERROR_API);
+  });
+
+  it("shows API issues if not responses are 404 and all errors are triggered", () => {
+    const error: PreflightChecklistErrors = {
+      every: true,
+      some: true,
+      findings: new Error("some error"),
+      pkg: new Error("some error"),
+      repo: new Error("some error"),
+      scripts: new Error("some error")
+    };
+
     expect(flowProjectState({ ...blank, error })).toBe(ERROR_UNKNOWN);
   });
 });

--- a/src/content/headsup/PreflightProjectState.test.ts
+++ b/src/content/headsup/PreflightProjectState.test.ts
@@ -1,0 +1,83 @@
+import { flowProjectState } from "@r2c/extension/content/headsup";
+import {
+  PreflightChecklistErrors,
+  PreflightChecklistLoading
+} from "@r2c/extension/content/headsup/PreflightFetch";
+import {
+  ERROR_UNKNOWN,
+  LOADING_ALL,
+  LOADING_SOME
+} from "@r2c/extension/content/headsup/PreflightProjectState";
+
+describe("Project state", () => {
+  const notLoading: PreflightChecklistLoading = {
+    every: false,
+    some: false,
+    findings: false,
+    pkg: false,
+    repo: false,
+    scripts: false
+  };
+  const blank = {
+    loading: notLoading,
+    error: undefined,
+    data: undefined,
+    response: undefined
+  };
+
+  it("shows when everything is loading", () => {
+    const loading: PreflightChecklistLoading = {
+      every: true,
+      some: true,
+      findings: true,
+      pkg: true,
+      repo: true,
+      scripts: true
+    };
+    expect(flowProjectState({ ...blank, loading })).toBe(LOADING_ALL);
+  });
+
+  it("shows partial loading when some stuff is loading", () => {
+    const loading: PreflightChecklistLoading = {
+      every: false,
+      some: true,
+      findings: true,
+      pkg: true,
+      repo: true,
+      scripts: true
+    };
+    expect(flowProjectState({ ...blank, loading })).toBe(LOADING_SOME);
+  });
+
+  it("shows partial loading even if errors show up", () => {
+    const loading: PreflightChecklistLoading = {
+      every: false,
+      some: true,
+      findings: true,
+      pkg: true,
+      repo: true,
+      scripts: true
+    };
+    const error: PreflightChecklistErrors = {
+      every: false,
+      some: true,
+      findings: undefined,
+      pkg: undefined,
+      repo: undefined,
+      scripts: new Error("some error")
+    };
+    expect(flowProjectState({ ...blank, loading, error })).toBe(LOADING_SOME);
+  });
+
+  it("shows unknown error when some responses have errored out and there's no data", () => {
+    const error: PreflightChecklistErrors = {
+      every: false,
+      some: true,
+      findings: undefined,
+      pkg: undefined,
+      repo: undefined,
+      scripts: new Error("some error")
+    };
+    expect(flowProjectState({ ...blank, error })).toBe(ERROR_UNKNOWN);
+  });
+});

--- a/src/content/headsup/PreflightProjectState.tsx
+++ b/src/content/headsup/PreflightProjectState.tsx
@@ -1,0 +1,54 @@
+export type PreflightProjectState =
+  | "complete"
+  | "partial"
+  | "loading-all"
+  | "loading-some"
+  | "empty-unsupported"
+  | "error-missing-data"
+  | "error-api"
+  | "error-unknown";
+
+/**
+ * Don't export. Internal alias for this file only to save my keyboard quota.
+ */
+type PPS = PreflightProjectState;
+
+/**
+ * We've finished loading all data, and it's all there
+ */
+export const COMPLETE: PPS = "complete";
+
+/**
+ * We've loaded all data, only some data is available for the current commit
+ */
+export const PARTIAL: PPS = "partial";
+
+/**
+ * We're still in the middle of loading everything and no data is finished loading.
+ */
+export const LOADING_ALL: PPS = "loading-all";
+
+/**
+ * We're loading some data, but some of the data is finished and ready.
+ */
+export const LOADING_SOME: PPS = "loading-some";
+
+/**
+ * We don't have data because we don't support this language or project.
+ */
+export const EMPTY_UNSUPPORTED: PPS = "empty-unsupported";
+
+/**
+ * We should have data, but for some reason we don't.
+ */
+export const ERROR_MISSING_DATA: PPS = "error-missing-data";
+
+/**
+ * Something's going wrong with the API.
+ */
+export const ERROR_API: PPS = "error-api";
+
+/**
+ * We have no idea what's going on.
+ */
+export const ERROR_UNKNOWN: PPS = "error-unknown";

--- a/src/content/headsup/UsedBy.tsx
+++ b/src/content/headsup/UsedBy.tsx
@@ -1,22 +1,33 @@
+import { Classes } from "@blueprintjs/core";
 import { PackageEntry, PackageResponse } from "@r2c/extension/api/package";
 import NonIdealInline from "@r2c/extension/content/NonIdealInline";
 import ProfilePicture from "@r2c/extension/shared/ProfilePicture";
+import * as classnames from "classnames";
 import { flatten, uniq } from "lodash";
 import * as React from "react";
 import "./UsedBy.css";
 
 interface UsedByProps {
   pkg: PackageResponse;
+  loading: boolean | null;
   selectedPackage: PackageEntry;
 }
 
 export default class UsedBy extends React.PureComponent<UsedByProps> {
   public render() {
-    const { pkg, selectedPackage } = this.props;
+    const { pkg, selectedPackage, loading } = this.props;
     const endorsers = flatten(pkg.packages.map(entry => entry.endorsers));
     const uniqueEndorsers = uniq(endorsers);
 
-    if (endorsers.length === 0) {
+    if (loading) {
+      return (
+        <NonIdealInline
+          icon="airplane"
+          className={classnames("related-package-nonideal", Classes.SKELETON)}
+          message="Loading..."
+        />
+      );
+    } else if (endorsers.length === 0) {
       return (
         <NonIdealInline
           icon="blocked-person"

--- a/src/content/headsup/index.tsx
+++ b/src/content/headsup/index.tsx
@@ -68,7 +68,7 @@ class RepoHeadsUp extends React.PureComponent<HeadsUpProps, RepoHeadsUpState> {
         <PreflightFetch>
           {fetchResponse => {
             const { loading, error, data } = fetchResponse;
-            const state = this.flowProjectState(fetchResponse);
+            const state = flowProjectState(fetchResponse);
 
             switch (state) {
               case ProjectState.LOADING_ALL:
@@ -112,53 +112,38 @@ class RepoHeadsUp extends React.PureComponent<HeadsUpProps, RepoHeadsUpState> {
       );
     }
   }
+}
 
-  private flowProjectState({
-    data,
-    loading,
-    error,
-    response
-  }: PreflightChecklistFetchResponse): ProjectState.PreflightProjectState {
-    console.log(data, loading, error, response);
-    if (loading != null && loading.some) {
-      if (loading.every) {
-        console.log("All loading");
-
-        return ProjectState.LOADING_ALL;
-      } else {
-        console.log("Some loading");
-
-        return ProjectState.LOADING_SOME;
-      }
-    } else if (response != null && error != null && error.every) {
-      if (
-        (Object.keys(response) as (keyof PreflightChecklistFetchData)[]).every(
-          k => response[k] != null && response[k].status === 404
-        )
-      ) {
-        console.log("Everything is 404");
-
-        return ProjectState.ERROR_MISSING_DATA;
-      } else {
-        console.log("Everything is error, but also 404");
-
-        return ProjectState.ERROR_API;
-      }
-    } else if (data != null && data.some) {
-      if (data.every) {
-        console.log("All complete");
-
-        return ProjectState.COMPLETE;
-      } else {
-        console.log("Partial complete");
-
-        return ProjectState.PARTIAL;
-      }
+export function flowProjectState({
+  data,
+  loading,
+  error,
+  response
+}: PreflightChecklistFetchResponse): ProjectState.PreflightProjectState {
+  if (loading != null && loading.some) {
+    if (loading.every) {
+      return ProjectState.LOADING_ALL;
     } else {
-      console.log("Unknown error");
-
-      return ProjectState.ERROR_UNKNOWN;
+      return ProjectState.LOADING_SOME;
     }
+  } else if (response != null && error != null && error.every) {
+    if (
+      (Object.keys(response) as (keyof PreflightChecklistFetchData)[]).every(
+        k => response[k] != null && response[k].status === 404
+      )
+    ) {
+      return ProjectState.ERROR_MISSING_DATA;
+    } else {
+      return ProjectState.ERROR_API;
+    }
+  } else if (data != null && data.some) {
+    if (data.every) {
+      return ProjectState.COMPLETE;
+    } else {
+      return ProjectState.PARTIAL;
+    }
+  } else {
+    return ProjectState.ERROR_UNKNOWN;
   }
 }
 

--- a/stories/Headsup.stories.tsx
+++ b/stories/Headsup.stories.tsx
@@ -4,6 +4,7 @@ import {
   LoadingHeadsUp,
   UnsupportedHeadsUp
 } from "@r2c/extension/content/headsup/NonIdealHeadsup";
+import { ERROR_UNKNOWN } from "@r2c/extension/content/headsup/PreflightProjectState";
 import centered from "@storybook/addon-centered";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
@@ -12,7 +13,10 @@ storiesOf("Headsup", module)
   .addDecorator(centered)
   .add("Non-ideal, loading", () => <LoadingHeadsUp />)
   .add("Non-ideal, error, Error()", () => (
-    <ErrorHeadsUp error={new Error("Example error")} />
+    <ErrorHeadsUp
+      projectState={ERROR_UNKNOWN}
+      error={new Error("Example error")}
+    />
   ))
   .add("Non-ideal, unsupported", () => <UnsupportedHeadsUp />)
   .add("Exceptional", () => <ExceptionalHeadsUp />);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs"
-  }
+    "module": "commonjs",
+    "paths": {
+      "@r2c/extension/*": ["src/*"]
+    },
+    "baseUrl": "../"
+  },
+  "include": ["../**/*"]
 }


### PR DESCRIPTION
This PR separates out retrieving NPM scripts data into using the new `scripts` endpoint in the API. Should prevent blocking a successful package request because we couldn't detect NPM install scripts in the project.