### PR TITLE
Added popup settings switch for always hiding on unsupported state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - You can now hide the "unsupported project" banner from always appearing (#122) (thanks @jruhland for the feedback!)
+- There is also a switch for toggling between showing the "unsupported project" banner in the popup settings! (#165)
 
 ### Changed
 

--- a/src/popup/ExtensionTab.tsx
+++ b/src/popup/ExtensionTab.tsx
@@ -77,6 +77,13 @@ export default class ExtensionTab extends React.Component<ExtensionTabProps> {
             experimentName="permissions"
             onToggleExperiment={this.props.onToggleExperiment}
           />
+          <ExperimentSwitch
+            title="Hide headsup"
+            description="We'll hide the headsup component on unsupported repositories."
+            experiments={this.props.extensionState.experiments}
+            experimentName="hideOnUnsupported"
+            onToggleExperiment={this.props.onToggleExperiment}
+          />
         </FormGroup>
       </div>
     );

--- a/src/popup/ExtensionTab.tsx
+++ b/src/popup/ExtensionTab.tsx
@@ -78,8 +78,8 @@ export default class ExtensionTab extends React.Component<ExtensionTabProps> {
             onToggleExperiment={this.props.onToggleExperiment}
           />
           <ExperimentSwitch
-            title="Hide headsup"
-            description="We'll hide the headsup component on unsupported repositories."
+            title="Hide on unsupported projects"
+            description="We'll hide the unsupported project banner from appearing on JavaScript/ TypeScript repositories."
             experiments={this.props.extensionState.experiments}
             experimentName="hideOnUnsupported"
             onToggleExperiment={this.props.onToggleExperiment}


### PR DESCRIPTION
<img width="373" alt="screen shot 2018-11-05 at 10 51 39 am" src="https://user-images.githubusercontent.com/5661037/48019661-d2e41e80-e0e8-11e8-9acb-a4176bebbb91.png">

Might want to change the copy.
Works with the Always hide button in the headsup component as well since both are linked to the extension state. 