### PR TITLE
Added links to both preflight text and r2c icon in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-<<<<<<< HEAD
-- Made "preflight" header and R2C logo link to the browser's GitHub repo and the R2C website respectively
-=======
-- Added link to secarta extension on github on the preflight text in the header as well as a link to R2C's website on the R2C logo in the header.
->>>>>>> 15932c85a5c339827843ff6b39ab7cb2d6aeca6b
+- Made preflight title and R2C logo link to the browser extension's GitHub repo and the R2C website respectively
 
 ## [1.14.0] - 2018-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Made "preflight" header and R2C logo link to the browser's GitHub repo and the R2C website respectively
+
 ## [1.14.0] - 2018-11-27
 
 ### Added
 
 - Added support for R2C to flag projects as malicious / do not use (e.g. [event-stream](https://github.com/dominictarr/event-stream))
-- Added link to secarta extension on github on the preflight text in the header as well as a link to R2C's website on the R2C logo in the header.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added support for R2C to flag projects as malicious / do not use (e.g. [event-stream](https://github.com/dominictarr/event-stream))
+- Added link to secarta extension on github on the preflight text in the header as well as a link to R2C's website on the R2C logo in the header.
 
 ### Fixed
 

--- a/src/content/headsup/NormalHeadsup.tsx
+++ b/src/content/headsup/NormalHeadsup.tsx
@@ -38,7 +38,11 @@ export default class NormalHeadsUp extends React.PureComponent<
       <div className="r2c-repo-headsup checklist-headsup">
         <header>
           <div className="checklist-left">
-            <span className="preflight-logo">preflight</span>
+            <span className="preflight-logo">
+              <a href="https://github.com/returntocorp/secarta-extension/">
+                preflight
+              </a>
+            </span>
           </div>
           <div className="checklist-right">
             {data.repo != null && (

--- a/src/content/headsup/NormalHeadsup.tsx
+++ b/src/content/headsup/NormalHeadsup.tsx
@@ -9,7 +9,7 @@ import {
 import RelatedPackages from "@r2c/extension/content/headsup/RelatedPackages";
 import UsedBy from "@r2c/extension/content/headsup/UsedBy";
 import LastUpdatedBadge from "@r2c/extension/content/LastUpdatedBadge";
-import { R2CLogo } from "@r2c/extension/icons";
+import { R2CLogoLink } from "@r2c/extension/icons";
 import * as React from "react";
 import "./index.css";
 
@@ -52,7 +52,7 @@ export default class NormalHeadsUp extends React.PureComponent<
                 repoSlug={repoSlug}
               />
             )}
-            <R2CLogo />
+            <R2CLogoLink />
           </div>
         </header>
         <div className="repo-headsup-body">

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -12,22 +12,26 @@ export const R2CLogo: React.SFC<R2CLogoProps> = ({
   width,
   fill = "white"
 }) => (
+  <svg
+    width={width != null ? width : "134"}
+    height={width != null ? undefined : "174"}
+    viewBox="0 0 134 174"
+    fill="transparent"
+    className={classnames("r2c-logo", className)}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      className="r2c-logo-path"
+      d="M32.7444 0L0 33.0664L32.7444 66.1328L44.6218 54.1384L23.7549 33.0664L44.6218 11.9944L32.7444 0ZM134 174L44.3364 111.69H82.0891C106.243 111.69 126.71 91.5894 126.71 66.6414C126.71 42.0725 108.292 21.5928 82.0891 21.5928H50.8916L39.8159 32.7773L50.8916 43.9617H82.0891C95.4746 43.9617 104.536 53.8428 104.536 66.6414C104.536 79.0847 94.1465 89.321 82.0891 89.321H1.25049V110.335L94.4165 174H134Z"
+      fill={fill}
+    />
+  </svg>
+);
+
+export const R2CLogoLink: React.SFC<R2CLogoProps> = props => (
   <a href="https://returntocorp.com/">
-    <svg
-      width={width != null ? width : "134"}
-      height={width != null ? undefined : "174"}
-      viewBox="0 0 134 174"
-      fill="transparent"
-      className={classnames("r2c-logo", className)}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        className="r2c-logo-path"
-        d="M32.7444 0L0 33.0664L32.7444 66.1328L44.6218 54.1384L23.7549 33.0664L44.6218 11.9944L32.7444 0ZM134 174L44.3364 111.69H82.0891C106.243 111.69 126.71 91.5894 126.71 66.6414C126.71 42.0725 108.292 21.5928 82.0891 21.5928H50.8916L39.8159 32.7773L50.8916 43.9617H82.0891C95.4746 43.9617 104.536 53.8428 104.536 66.6414C104.536 79.0847 94.1465 89.321 82.0891 89.321H1.25049V110.335L94.4165 174H134Z"
-        fill={fill}
-      />
-    </svg>
+    <R2CLogo {...props} />
   </a>
 );
 

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -12,21 +12,23 @@ export const R2CLogo: React.SFC<R2CLogoProps> = ({
   width,
   fill = "white"
 }) => (
-  <svg
-    width={width != null ? width : "134"}
-    height={width != null ? undefined : "174"}
-    viewBox="0 0 134 174"
-    fill="transparent"
-    className={classnames("r2c-logo", className)}
-  >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      className="r2c-logo-path"
-      d="M32.7444 0L0 33.0664L32.7444 66.1328L44.6218 54.1384L23.7549 33.0664L44.6218 11.9944L32.7444 0ZM134 174L44.3364 111.69H82.0891C106.243 111.69 126.71 91.5894 126.71 66.6414C126.71 42.0725 108.292 21.5928 82.0891 21.5928H50.8916L39.8159 32.7773L50.8916 43.9617H82.0891C95.4746 43.9617 104.536 53.8428 104.536 66.6414C104.536 79.0847 94.1465 89.321 82.0891 89.321H1.25049V110.335L94.4165 174H134Z"
-      fill={fill}
-    />
-  </svg>
+  <a href="https://returntocorp.com/">
+    <svg
+      width={width != null ? width : "134"}
+      height={width != null ? undefined : "174"}
+      viewBox="0 0 134 174"
+      fill="transparent"
+      className={classnames("r2c-logo", className)}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        className="r2c-logo-path"
+        d="M32.7444 0L0 33.0664L32.7444 66.1328L44.6218 54.1384L23.7549 33.0664L44.6218 11.9944L32.7444 0ZM134 174L44.3364 111.69H82.0891C106.243 111.69 126.71 91.5894 126.71 66.6414C126.71 42.0725 108.292 21.5928 82.0891 21.5928H50.8916L39.8159 32.7773L50.8916 43.9617H82.0891C95.4746 43.9617 104.536 53.8428 104.536 66.6414C104.536 79.0847 94.1465 89.321 82.0891 89.321H1.25049V110.335L94.4165 174H134Z"
+        fill={fill}
+      />
+    </svg>
+  </a>
 );
 
 export const QuestionMarkIcon: React.SFC = () => (


### PR DESCRIPTION
Before
![screen shot 2018-11-27 at 4 15 15 pm](https://user-images.githubusercontent.com/5661037/49119982-a642a300-f25f-11e8-8386-b8d0231ee64c.png)

After
![screen shot 2018-11-27 at 3 00 44 pm](https://user-images.githubusercontent.com/5661037/49117363-46df9580-f255-11e8-8295-4a065fba84e3.png)