### PR TITLE
Enable permission by default and show bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Made preflight title and R2C logo link to the browser extension's GitHub repo and the R2C website respectively
+- Enabled permissions by default
+- Added permissions findings inline to be same as inline issues findings
 
 ## [1.14.0] - 2018-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Made preflight title and R2C logo link to the browser extension's GitHub repo and the R2C website respectively
-- Enabled permissions by default
-- Added permissions findings inline to be same as inline issues findings
+- Promoted our permissions experiment to a "permanent" feature that is always on
+- When viewing a file in GitHub, we now mark lines that are related to a permission as well as issues
 
 ## [1.14.0] - 2018-11-27
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/enzyme": "^3.1.15",
     "@types/intercom-web": "^2.8.4",
     "@types/jest": "^23.3.1",
-    "@types/lodash": "^4.14.116",
+    "@types/lodash": "^4.14.118",
     "@types/node": "~10.10.2",
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",

--- a/src/content/PreflightTwist.tsx
+++ b/src/content/PreflightTwist.tsx
@@ -224,14 +224,11 @@ export default class PreflightTwist extends React.PureComponent<
           <ExtensionContext.Consumer>
             {({ extensionState }) => (
               <div className="twist-body">
-                {extensionState != null &&
-                  extensionState.experiments.permissions && (
-                    <WrappedPreflightPermissionsDetails
-                      domRef={this.twistRefs.permissions}
-                      focused={deepLink === "permissions"}
-                      repoSlug={repoSlug}
-                    />
-                  )}
+                <WrappedPreflightPermissionsDetails
+                  domRef={this.twistRefs.permissions}
+                  focused={deepLink === "permissions"}
+                  repoSlug={repoSlug}
+                />
                 <WrappedPreflightVulnsDetails
                   domRef={this.twistRefs.vulns}
                   focused={deepLink === "vulns"}

--- a/src/content/headsup/PreflightChecklist.tsx
+++ b/src/content/headsup/PreflightChecklist.tsx
@@ -348,13 +348,10 @@ export class PreflightChecklist extends React.PureComponent<
         <ExtensionContext.Consumer>
           {({ extensionState }) => (
             <ul className="preflight-checklist">
-              {extensionState != null &&
-                extensionState.experiments.permissions && (
-                  <PreflightPermissionsItem
-                    repoSlug={repoSlug}
-                    onChecklistItemClick={o}
-                  />
-                )}
+              <PreflightPermissionsItem
+                repoSlug={repoSlug}
+                onChecklistItemClick={o}
+              />
               <PreflightScriptsItem
                 repoSlug={repoSlug}
                 scripts={

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -127,7 +127,7 @@ class ContentHost extends React.Component<{}, ContentHostState> {
                         get(findingsData, "commitHash");
 
                       if (commitHash == null) {
-                        return;
+                        return null;
                       }
 
                       return (

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -112,19 +112,29 @@ class ContentHost extends React.Component<{}, ContentHostState> {
                       loading: permissionsLoading,
                       error: permissionsError
                     }) => {
+                      let findings: FindingEntry[] = [];
+                      let commitHash = null;
                       if (
-                        findingsData == null ||
-                        findingsData.findings == null ||
-                        permissionsData == null ||
-                        permissionsData.permissions == null
+                        findingsData != null &&
+                        findingsData.findings != null
                       ) {
+                        findings = findings.concat(findingsData.findings);
+                        commitHash = findingsData.commitHash;
+                      }
+                      if (
+                        permissionsData != null &&
+                        permissionsData.permissions != null
+                      ) {
+                        findings = findings.concat(
+                          this.getFindingsFromPermissions(
+                            permissionsData.permissions
+                          )
+                        );
+                        commitHash = permissionsData.commitHash;
+                      }
+                      if (commitHash == null) {
                         return;
                       }
-                      const findings = findingsData.findings.concat(
-                        this.getFindingsFromPermissions(
-                          permissionsData.permissions
-                        )
-                      );
 
                       return (
                         <>
@@ -132,7 +142,7 @@ class ContentHost extends React.Component<{}, ContentHostState> {
                             key={`BlobFindingsInjector ${
                               this.state.currentUrl
                             } ${this.state.navigationNonce}`}
-                            findingCommitHash={findingsData.commitHash}
+                            findingCommitHash={commitHash}
                             findings={findings}
                             repoSlug={this.repoSlug}
                           />
@@ -141,7 +151,7 @@ class ContentHost extends React.Component<{}, ContentHostState> {
                               this.state.currentUrl
                             } ${this.state.navigationNonce}`}
                             findings={findings}
-                            commitHash={findingsData.commitHash}
+                            commitHash={commitHash}
                             repoSlug={this.repoSlug}
                           />
                         </>

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,6 +1,9 @@
 import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";
 import { FindingEntry, FindingsFetch } from "@r2c/extension/api/findings";
-import { PermissionsFetch, PermissionsResponse } from "@r2c/extension/api/permissions";
+import {
+  PermissionsFetch,
+  PermissionsResponse
+} from "@r2c/extension/api/permissions";
 import BlobFindingsInjector from "@r2c/extension/content/github/BlobFindingsInjector";
 import { naivelyExtractCurrentUserFromPage } from "@r2c/extension/content/github/dom";
 import TreeFindingsInjector from "@r2c/extension/content/github/TreeFindingsInjector";
@@ -8,8 +11,17 @@ import RepoHeadsUpInjector from "@r2c/extension/content/headsup";
 import PreflightTwist from "@r2c/extension/content/PreflightTwist";
 import Twist, { TwistId } from "@r2c/extension/content/Twist";
 import Twists from "@r2c/extension/content/Twists";
-import { ExtensionState, getExtensionState } from "@r2c/extension/shared/ExtensionState";
-import { fetchOrCreateExtensionUniqueId, getCurrentUrlWithoutHash, isGitHubSlug, isRepositoryPrivate, naivelyExtractSlugFromCurrentUrl } from "@r2c/extension/utils";
+import {
+  ExtensionState,
+  getExtensionState
+} from "@r2c/extension/shared/ExtensionState";
+import {
+  fetchOrCreateExtensionUniqueId,
+  getCurrentUrlWithoutHash,
+  isGitHubSlug,
+  isRepositoryPrivate,
+  naivelyExtractSlugFromCurrentUrl
+} from "@r2c/extension/utils";
 import { concat, flatten, get } from "lodash";
 import * as React from "react";
 import { PlaneIcon } from "../icons";
@@ -110,7 +122,7 @@ class ContentHost extends React.Component<{}, ContentHostState> {
                         )
                       );
 
-                      const commitHash =
+                      const commitHash: string | undefined =
                         get(permissionsData, "commitHash") ||
                         get(findingsData, "commitHash");
 

--- a/src/popup/ExtensionTab.tsx
+++ b/src/popup/ExtensionTab.tsx
@@ -71,13 +71,6 @@ export default class ExtensionTab extends React.Component<ExtensionTabProps> {
           className="extension-experiments-cp"
         >
           <ExperimentSwitch
-            title="Permission checks"
-            description="We'll show capabilities and permissions that we've detected in this project as issues you can interact with."
-            experiments={this.props.extensionState.experiments}
-            experimentName="permissions"
-            onToggleExperiment={this.props.onToggleExperiment}
-          />
-          <ExperimentSwitch
             title="Hide on unsupported projects"
             description="We'll hide the unsupported project banner from appearing on JavaScript / TypeScript repositories."
             experiments={this.props.extensionState.experiments}

--- a/src/shared/ExtensionState.tsx
+++ b/src/shared/ExtensionState.tsx
@@ -1,14 +1,10 @@
 import { fetchFromStorage, updateStorage } from "@r2c/extension/utils";
 
-export type ExperimentName =
-  | "permissions"
-  | "hideOnUnsupported"
-  | "emptyPlaceholder";
+export type ExperimentName = "hideOnUnsupported" | "emptyPlaceholder";
 
 export type ExperimentManifest = { [E in ExperimentName]: boolean };
 
 const DEFAULT_EXPERIMENTS: ExperimentManifest = {
-  permissions: true,
   hideOnUnsupported: false,
   emptyPlaceholder: false
 };

--- a/src/shared/ExtensionState.tsx
+++ b/src/shared/ExtensionState.tsx
@@ -8,7 +8,7 @@ export type ExperimentName =
 export type ExperimentManifest = { [E in ExperimentName]: boolean };
 
 const DEFAULT_EXPERIMENTS: ExperimentManifest = {
-  permissions: false,
+  permissions: true,
   hideOnUnsupported: false,
   emptyPlaceholder: false
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,9 +323,10 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
 
-"@types/lodash@^4.14.116":
-  version "4.14.116"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
+"@types/lodash@^4.14.118":
+  version "4.14.118"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
+  integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
 
 "@types/node@*":
   version "10.11.4"


### PR DESCRIPTION
Enable permissions by default (remove from experiments) and show permission findings inline

Testing:
1. Load CRX and see permissions enabled by default
<img width="1573" alt="screen shot 2018-12-03 at 9 17 56 pm" src="https://user-images.githubusercontent.com/1626382/49420575-fb3f5700-f740-11e8-9e98-bd9e2bdc75c7.png">
2. Click thru on permissions and see red bubble in line
<img width="1633" alt="screen shot 2018-12-03 at 9 18 08 pm" src="https://user-images.githubusercontent.com/1626382/49420576-fbd7ed80-f740-11e8-8850-b154c74c0bb4.png">
3. No permissions in settings:
<img width="447" alt="screen shot 2018-12-04 at 11 08 40 am" src="https://user-images.githubusercontent.com/1626382/49466600-59a61d00-f7b5-11e8-81ea-c6a9e2ea8908.png">
